### PR TITLE
249132: Create pipeline action

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "private": true,
   "engines": {
     "node": "18 || 20"

--- a/app/packages/backend/src/plugins/scaffolder.ts
+++ b/app/packages/backend/src/plugins/scaffolder.ts
@@ -7,11 +7,11 @@ import { Router } from 'express';
 import type { PluginEnvironment } from '../types';
 import { ScmIntegrations } from '@backstage/integration';
 import {
-  createAzurePipelineAction,
   permitAzurePipelineAction,
   runAzurePipelineAction,
 } from '@antoniobergas/scaffolder-backend-module-azure-pipelines';
 import {
+  createPipelineAction,
   getServiceConnectionAction,
 } from '@internal/backstage-plugin-scaffolder-backend-module-adp-scaffolder-actions';
 
@@ -33,9 +33,12 @@ export default async function createPlugin(
 
   const actions = [
     ...builtInActions,
-    createAzurePipelineAction({ integrations }),
     permitAzurePipelineAction({ integrations }),
     runAzurePipelineAction({ integrations }),
+    createPipelineAction({
+      integrations: integrations,
+      config: env.config,
+    }),
     getServiceConnectionAction({
       integrations: integrations,
       config: env.config,

--- a/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/README.md
+++ b/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/README.md
@@ -7,5 +7,6 @@ Details about actions (inputs, outputs, and how to use them) are available in [t
 
 - Azure DevOps
   - Get Service Connection
+  - Create Pipeline
 
 _This plugin was created through the Backstage CLI_

--- a/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/actions/azure-devops/createPipeline.test.ts
+++ b/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/actions/azure-devops/createPipeline.test.ts
@@ -1,0 +1,194 @@
+import { ConfigReader } from "@backstage/config";
+import { ScmIntegrations } from "@backstage/integration";
+import { createPipelineAction } from "./createPipeline";
+import { getVoidLogger } from "@backstage/backend-common";
+import { PassThrough } from 'stream';
+import { RestClient } from "typed-rest-client";
+
+jest.mock('azure-devops-node-api', () => ({
+  getHandlerFromToken: jest.fn().mockReturnValue(() => {}),
+  getPersonalAccessTokenHandler: jest.fn().mockReturnValue(() => {}),
+}));
+
+jest.mock('typed-rest-client', () => ({
+  RestClient: jest.fn(),
+}));
+
+describe('adp:azure:pipeline:create', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const config = new ConfigReader({
+    azureDevOps: {
+      host: 'dev.azure.com',
+      token: 'token',
+      organization: 'org',
+    },
+    integrations: {
+      azure: [
+        {
+          host: 'dev.azure.com',
+          credentials: [{ personalAccessToken: 'faketoken' }],
+        },
+      ],
+    },
+  });
+
+  const integrations = ScmIntegrations.fromConfig(config);
+  const action = createPipelineAction({
+    integrations: integrations,
+    config: config,
+  });
+
+  const mockContext = {
+    input: {
+      project: 'test-project',
+      folder: '/test/folder',
+      pipelineName: 'test-pipeline',
+      repositoryName: 'defra/test-repository',
+      yamlPath: './azuredevops/build.yaml',
+      serviceConnectionId: '12345'
+    },
+    workspacePath: 'test-workspace',
+    logger: getVoidLogger(),
+    logStream: new PassThrough(),
+    output: jest.fn(),
+    createTemporaryDirectory: jest.fn(),
+  };
+
+  const mockCreator = {
+    create: jest.fn(),
+  };
+  (RestClient as unknown as jest.Mock).mockImplementation(() => mockCreator);
+
+  it('should throw if there is no integration config provided', async () => {
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: {
+          server: 'test.azure.com',
+          organization: 'another-test-org',
+          project: 'test-project',
+          folder: '/test/folder',
+          pipelineName: 'test-pipeline',
+          repositoryName: 'defra/test-repository',
+          yamlPath: './azuredevops/build.yaml',
+          serviceConnectionId: '12345'
+        },
+      }),
+    ).rejects.toThrow(/No credentials provided/);
+  });
+
+  it('should throw if no response is returned', async () => {
+    await expect(action.handler(mockContext)).rejects.toThrow(
+      /Could not get response from resource/,
+    );
+  });
+
+  it.each([101, 301, 418, 500])(
+    'should throw if a non-success status code is returned',
+    async statusCode => {
+      mockCreator.create.mockImplementation(() => ({
+        statusCode: statusCode,
+      }));
+
+      await expect(action.handler(mockContext)).rejects.toThrow(
+        /Could not get response from resource/,
+      );
+    },
+  );
+
+  it('should throw if a pipeline is not created', async () => {
+    mockCreator.create.mockImplementation(() => ({
+      statusCode: 200,
+      result: null,
+    }));
+
+    await expect(action.handler(mockContext)).rejects.toThrow(
+      /Unable to create new pipeline/,
+    );
+  });
+
+  it('should call the Azure API with the correct values', async () => {
+    mockCreator.create.mockImplementation(() => ({
+      statusCode: 200,
+      result: {
+        _links: {
+          web: {
+            href: 'http://dev.azure.com/link/to/pipeline'
+          }
+        },
+        url: 'http://dev.azure.com/link/to/pipeline',
+        id: 1234,
+        revision: '1',
+        name: 'pipeline-name',
+        folder: 'folder\\path'
+      },
+    }));
+
+    await action.handler(mockContext);
+
+    expect(RestClient).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('dev.azure.com'),
+      expect.any(Array),
+    );
+
+    expect(mockCreator.create).toHaveBeenCalledWith(
+      expect.stringContaining(mockContext.input.project),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it('should store the pipeline ID in the action context output', async () => {
+    mockCreator.create.mockImplementation(() => ({
+      statusCode: 200,
+      result: {
+        _links: {
+          web: {
+            href: 'http://dev.azure.com/link/to/pipeline'
+          }
+        },
+        url: 'http://dev.azure.com/link/to/pipeline',
+        id: 1234,
+        revision: '1',
+        name: 'pipeline-name',
+        folder: 'folder\\path'
+      },
+    }));
+
+    await action.handler(mockContext);
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'pipelineId',
+      1234,
+    );
+  });
+
+  it('should store the pipeline URL in the action context output', async () => {
+    mockCreator.create.mockImplementation(() => ({
+      statusCode: 200,
+      result: {
+        _links: {
+          web: {
+            href: 'http://dev.azure.com/link/to/pipeline'
+          }
+        },
+        url: 'http://dev.azure.com/link/to/pipeline',
+        id: 1234,
+        revision: '1',
+        name: 'pipeline-name',
+        folder: 'folder\\path'
+      },
+    }));
+
+    await action.handler(mockContext);
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'pipelineUrl',
+      'http://dev.azure.com/link/to/pipeline',
+    );
+  });
+});

--- a/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/actions/azure-devops/createPipeline.ts
+++ b/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/actions/azure-devops/createPipeline.ts
@@ -1,0 +1,231 @@
+import { Config } from '@backstage/config';
+import { InputError, ServiceUnavailableError } from '@backstage/errors';
+import {
+  DefaultAzureDevOpsCredentialsProvider,
+  ScmIntegrationRegistry,
+} from '@backstage/integration';
+import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+import {
+  getPersonalAccessTokenHandler,
+  getHandlerFromToken,
+} from 'azure-devops-node-api';
+import { IRequestOptions, RestClient } from 'typed-rest-client';
+import { Pipeline } from './types';
+
+type CreatePipelineOptions = {
+  pipelineApiVersion?: string;
+  server?: string;
+  organization?: string;
+  project: string;
+  folder: string;
+  pipelineName: string;
+  repositoryName: string;
+  yamlPath?: string;
+  serviceConnectionId: string;
+};
+
+type Repository = {
+  fullName: string;
+  connection: {
+    id: string;
+  };
+  type: string;
+};
+
+type CreatePipelineConfiguration = {
+  type: string;
+  path: string;
+  repository: Repository;
+};
+
+type CreatePipelineRequest = {
+  folder: string;
+  name: string;
+  configuration: CreatePipelineConfiguration;
+};
+
+export function createPipelineAction(options: {
+  integrations: ScmIntegrationRegistry;
+  config: Config;
+}) {
+  const { integrations, config } = options;
+
+  return createTemplateAction<CreatePipelineOptions>({
+    id: 'adp:azure:pipeline:create',
+    description: 'Creates an Azure DevOps pipeline',
+    schema: {
+      input: {
+        required: [
+          'project',
+          'folder',
+          'pipelineName',
+          'repositoryName',
+          'serviceConnectionId',
+        ],
+        type: 'object',
+        properties: {
+          pipelineApiVersion: {
+            type: 'string',
+            title: 'API Version',
+            description:
+              'The Pipeline Endpoint API version to use. Defaults to 7.2-preview.1.',
+          },
+          server: {
+            type: 'string',
+            title: 'Server',
+            description:
+              'The hostname of the Azure DevOps service. Defaults to the azureDevOps.host config setting.',
+          },
+          organization: {
+            type: 'string',
+            title: 'Organization',
+            description:
+              'The name of the Azure DevOps organization. Defaults to the azureDevOps.organization config setting.',
+          },
+          project: {
+            type: 'string',
+            title: 'Project',
+            description:
+              'The name of the Azure DevOps project where the pipeline will be created',
+          },
+          folder: {
+            type: 'string',
+            title: 'Folder',
+            description:
+              'The name of the folder where the pipeline will be created.',
+          },
+          pipelineName: {
+            type: 'string',
+            title: 'Pipeline Name',
+            description: 'The name of the pipeline.',
+          },
+          repositoryName: {
+            type: 'string',
+            title: 'Repository Name',
+            description:
+              'The name of the GitHub repository. This must be in the format owner-name/repo-name',
+          },
+          yamlPath: {
+            type: 'string',
+            title: 'Azure DevOps Pipelines Definition',
+            description:
+              'The location of the Azure DevOps Pipeline definition file. Defaults to /azure-pipelines.yaml',
+          },
+          serviceConnectionId: {
+            title: 'Service Connection ID',
+            type: 'string',
+            description:
+              'The ID of the service connection for the GitHub repository.',
+          },
+        },
+      },
+      output: {
+        type: 'object',
+        properties: {
+          pipelineId: {
+            title: 'Pipeline ID',
+            type: 'number',
+            description: 'The ID of the created pipeline'
+          },
+          pipelineUrl: {
+            title: 'Pipeline URL',
+            type: 'string',
+            description: 'URL to the created pipeline'
+          }
+        }
+      },
+    },
+
+    async handler(ctx) {
+      const apiVersion = ctx.input.pipelineApiVersion ?? '7.2-preview.1';
+      const server = ctx.input.server ?? config.getString('azureDevOps.host');
+      const organization =
+        ctx.input.organization ?? config.getString('azureDevOps.organization');
+
+      const encodedOrganization = encodeURIComponent(organization);
+      const encodedProject = encodeURIComponent(ctx.input.project);
+
+      const url = `https://${server}/${encodedOrganization}`;
+
+      const credentialsProvider =
+        DefaultAzureDevOpsCredentialsProvider.fromIntegrations(integrations);
+      const credentials = await credentialsProvider.getCredentials({
+        url: url,
+      });
+
+      if (credentials === undefined) {
+        throw new InputError(
+          `No credentials provided for ${url}. Check your integrations config.`,
+        );
+      }
+
+      let authHandler;
+      if (!credentials || credentials.type === 'pat') {
+        const token = config.getString('azureDevOps.token');
+        authHandler = getPersonalAccessTokenHandler(token);
+      } else {
+        authHandler = getHandlerFromToken(credentials.token);
+      }
+
+      ctx.logger.info(
+        `Calling Azure DevOps REST API. Creating pipeline ${ctx.input.pipelineName} in project ${ctx.input.project}`,
+      );
+
+      const restClient = new RestClient(
+        'backstage-scaffolder',
+        `https://${server}`,
+        [authHandler],
+      );
+      const requestOptions: IRequestOptions = {
+        acceptHeader: 'application/json',
+      };
+      const resource = `/${encodedOrganization}/${encodedProject}/_apis/pipelines?api-version=${apiVersion}`;
+      const body: CreatePipelineRequest = {
+        folder: ctx.input.folder,
+        name: ctx.input.pipelineName,
+        configuration: {
+          path: ctx.input.yamlPath || '/azure-pipelines.yaml',
+          type: 'yaml',
+          repository: {
+            fullName: ctx.input.repositoryName,
+            type: 'github',
+            connection: {
+              id: ctx.input.serviceConnectionId,
+            },
+          },
+        },
+      };
+
+      ctx.logger.debug(`Calling resource ${resource} at host ${server}`);
+
+      const createPipelineResponse = await restClient.create<Pipeline>(
+        resource,
+        body,
+        requestOptions,
+      );
+
+      if (
+        !createPipelineResponse ||
+        createPipelineResponse.statusCode < 200 ||
+        createPipelineResponse.statusCode > 299
+      ) {
+        const message = createPipelineResponse?.statusCode
+          ? `Could not get response from resource ${resource}. Status code ${createPipelineResponse.statusCode}`
+          : `Could not get response from resource ${resource}.`;
+        throw new ServiceUnavailableError(message);
+      }
+
+      const pipeline = createPipelineResponse.result;
+
+      if (!pipeline) {
+        throw new InputError(
+          `Unable to create new pipeline in project ${ctx.input.project}`,
+        );
+      }
+
+      ctx.logger.info(`Pipeline created. Pipeline ID is ${pipeline.id}`);
+      ctx.output('pipelineId', pipeline.id);
+      ctx.output('pipelineUrl', pipeline._links.web.href);
+    },
+  });
+}

--- a/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/actions/azure-devops/getServiceConnection.ts
+++ b/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/actions/azure-devops/getServiceConnection.ts
@@ -28,7 +28,7 @@ export function getServiceConnectionAction(options: {
 
   return createTemplateAction<GetServiceConnectionOptions>({
     id: 'adp:azure:serviceconnection:get',
-    description: 'Gets a service connection from an ADO project',
+    description: 'Gets a service connection from an Azure DevOps project',
     schema: {
       input: {
         required: ['project', 'serviceConnectionName'],

--- a/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/actions/azure-devops/index.ts
+++ b/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/actions/azure-devops/index.ts
@@ -1,1 +1,2 @@
-export * from './getServiceConnection'; 
+export * from './getServiceConnection';
+export * from './createPipeline';

--- a/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/actions/azure-devops/types.ts
+++ b/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/actions/azure-devops/types.ts
@@ -14,3 +14,15 @@ export type ServiceEndpoint = {
   isReady: boolean;
   owner: string;
 };
+
+export type Pipeline = {
+  folder: string;
+  id: number;
+  name: string;
+  url: string;
+  _links: {
+    web: {
+      href: string;
+    };
+  };
+};

--- a/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/index.ts
+++ b/app/plugins/scaffolder-backend-module-adp-scaffolder-actions/src/index.ts
@@ -1,6 +1,6 @@
 /***/
 /**
- * The adp-scaffolder-actions module for @backstage/plugin-scaffolder-backend.
+ * Custom ADP-specific scaffolder actions for @backstage/plugin-scaffolder-backend.
  *
  * @packageDocumentation
  */

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -9010,7 +9010,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0":
+"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^17":
   version "17.0.25"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.25.tgz#e0e5b3571e1069625b3a3da2b279379aa33a0cb5"
   integrity sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==


### PR DESCRIPTION
# **What this PR does / why we need it**:
Custom scaffolder action to create ADO pipelines. While there is already an action out there for this, it is incompatible with newer versions of Backstage, does not support authentication via service principals, and cannot create pipelines from a GitHub repo.

[AB#249132](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/249132)

# **Special notes for your reviewer**
Creating pipelines isn't supported in ADO Node API so have implemented using REST API

# Testing
[defra-adp-sandpit.jc-pipeline-test-6](https://dev.azure.com/defragovuk/DEFRA-FFC/_build?definitionId=5739) created from repo [jc-test-pipeline-6](https://github.com/defra-adp-sandpit/jc-pipeline-test-6).

Test runs in CI pipeline - https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=448376&view=results

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [x] This PR contains tests
- [x] Version number in [package.json](https://github.com/DEFRA/adp-portal/blob/main/app/package.json#L3) has been updated


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
