### PR TITLE
274004: Documentation updates and also fixed logic for import AD groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,27 @@ Run the following commands from the `/app` directory:
 yarn install
 yarn dev
 ```
+
+
+## Feature Requests
+
+If you have an idea for a new feature or an improvement to an existing feature, please follow these steps:
+
+1. Check if the feature has already been requested by searching the project's issue tracker.
+2. If the feature hasn't been requested, create a new issue and provide a clear description of the proposed feature and why it would be beneficial.
+
+## Pull Requests
+
+If you're ready to submit your code changes, please follow these steps specified in the [pull_request_template](../.github/pull_request_template.md)
+
+## Code Style Guidelines
+
+To maintain a consistent code style throughout the project, please adhere to the following guidelines:
+
+1. Use descriptive variable and function names.
+2. Follow the existing code formatting and indentation style.
+3. Write clear and concise comments to explain complex code logic.
+
+## License
+
+Include information about the project's license and any relevant copyright notices.

--- a/app/README.md
+++ b/app/README.md
@@ -1,8 +1,16 @@
-# [Backstage](https://backstage.io)
+# Azure Developer Platform Portal (ADP)
 
-This is your newly scaffolded Backstage App, Good Luck!
+The Azure Development Platform Portal built using [Backstage](https://backstage.io/). 
 
-To start the app, run:
+The Portal enables users to self service by providing the functionality below.
+
+- Onboard delivery programmes, projects and users onto the ADP Platform
+- Enable Developers to create microservices using software templates based on GDS standards
+
+
+## Getting Started
+
+Include instructions for getting the project set up locally. This may include steps to install dependencies, configure the development environment, and run the project.
 
 ```sh
 yarn install

--- a/app/app-config.yaml
+++ b/app/app-config.yaml
@@ -142,9 +142,9 @@ catalog:
         user:
           select: ['id', 'mail', 'displayName', 'description']
         userGroupMember:
-          filter: "displayName in ('${ADP_PORTAL_PLATFORM_ADMINS_GROUP}', '${ADP_PORTAL_PROGRAMME_ADMINS_GROUP}')"
+          filter: "displayName eq '${ADP_PORTAL_PLATFORM_ADMINS_GROUP}' or displayName eq '${ADP_PORTAL_PROGRAMME_ADMINS_GROUP}'"
         group:
-          filter: "displayName in ('${ADP_PORTAL_PLATFORM_ADMINS_GROUP}', '${ADP_PORTAL_PROGRAMME_ADMINS_GROUP}')"
+          filter: "displayName eq '${ADP_PORTAL_PLATFORM_ADMINS_GROUP}' or displayName eq '${ADP_PORTAL_PROGRAMME_ADMINS_GROUP}'"
         schedule:
           frequency: { hours: 1 }
           timeout: { minutes: 50 }

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "private": true,
   "engines": {
     "node": "18 || 20"

--- a/app/packages/backend/src/permissions/policies/adpPortalPermissionPolicy.ts
+++ b/app/packages/backend/src/permissions/policies/adpPortalPermissionPolicy.ts
@@ -34,7 +34,7 @@ export class AdpPortalPermissionPolicy implements PermissionPolicy {
   ): Promise<PolicyDecision> {
 
 
-    this.logger.info(
+    this.logger.debug(
       `User: identity.type - ${user?.identity.type} User: identity.userEntityRef - ${user?.identity.userEntityRef} User: identity.ownershipEntityRefs.length - ${user?.identity.ownershipEntityRefs.length} Request: type - ${request.permission.type}; name - ${request.permission.name}; action - ${request.permission.attributes.action}`,
     );
 

--- a/app/packages/backend/src/permissions/rbacUtilites.ts
+++ b/app/packages/backend/src/permissions/rbacUtilites.ts
@@ -25,7 +25,7 @@ export class RbacUtilities {
     this.programmeAdminGroup = `${this.groupPrefix}${rbacGroups.programmeAdminGroup.toLowerCase()}`
     this.adpPortalUsersGroup = `${this.groupPrefix}${rbacGroups.adpPortalUsersGroup.toLowerCase()}`
     
-    this.logger.info(`platformAdminsGroup=${this.platformAdminsGroup} | programmeAdminGroup=${this.programmeAdminGroup} | adpPortalUsersGroup= ${this.adpPortalUsersGroup}`)
+    this.logger.debug(`platformAdminsGroup=${this.platformAdminsGroup} | programmeAdminGroup=${this.programmeAdminGroup} | adpPortalUsersGroup= ${this.adpPortalUsersGroup}`)
   }
 
   public isInPlatformAdminGroup (user: BackstageIdentityResponse): boolean {


### PR DESCRIPTION
# **What this PR does / why we need it**:
Fixed the logic for specifying Microsoft AD groups. Replaced IN and EQ and OR
Also updated the documentation for the two README files
Changed the logging for the policy to debug, as these messages are only needed when debugging
*Link to the relevant work items: e.g: Relates to ADO Work Item [AB#274004](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/274004) and builds on #460593([https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=460593&view=results](https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=460593&view=results))*

# Testing
- All Tests run successfully locally
- Pipeline completed successfully.

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [x] This PR contains documentation
- [x] This PR contains tests
- [x] Version number in [package.json](https://github.com/DEFRA/adp-portal/blob/main/app/package.json#L3) has been updated


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2RnN3ZubTd6MnhycXUyZGg1dWNiemxtNHU1M3lyYnhqajV2aTRsNCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3oEjHV0z8S7WM4MwnK/giphy.gif)
