### PR TITLE
274004: Modifed permission policy to enable platform admins to create locations

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "private": true,
   "engines": {
     "node": "18 || 20"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "private": true,
   "engines": {
     "node": "18 || 20"

--- a/app/packages/backend/src/permissions/policies/adpPortalPermissionPolicy.test.ts
+++ b/app/packages/backend/src/permissions/policies/adpPortalPermissionPolicy.test.ts
@@ -56,26 +56,24 @@ describe('adpPortalPermissionPolicy: Platform Admin User', () => {
     { permission: catalogEntityRefreshPermission, expected: AuthorizeResult.ALLOW },
     { permission: catalogEntityCreatePermission, expected: AuthorizeResult.ALLOW },
     { permission: catalogEntityDeletePermission, expected: AuthorizeResult.ALLOW },
-    { permission: catalogLocationCreatePermission, expected: AuthorizeResult.DENY, skipVerifyFunctionWasCalled: true },
+    { permission: catalogLocationCreatePermission, expected: AuthorizeResult.ALLOW },
     { permission: catalogLocationDeletePermission, expected: AuthorizeResult.ALLOW },
   ])(
     'should allow access for permission $permission.name for the ADP Platform Admin Role',
-    async ({ permission, expected, skipVerifyFunctionWasCalled }) => {
+    async ({ permission, expected }) => {
 
       isInPlatformAdminGroupSpy.mockReturnValue(true)
       isIsInProgrammeAdminGroupSpy.mockReturnValue(false)
       isIsInAdpUserGroupSpy.mockReturnValue(false)
-      
+
       let mockRbacUtilities = new RbacUtilities(mockLogger, mockRbacGroups);
       const policy = new AdpPortalPermissionPolicy(mockRbacUtilities, mockLogger);
       const request: PolicyQuery = { permission: permission };
 
       let policyResult = await policy.handle(request, mockPlatformAdminUserResponse);
 
-      if (!skipVerifyFunctionWasCalled) {
-        expect(isInPlatformAdminGroupSpy).toHaveBeenCalled;
-        expect(isInPlatformAdminGroupSpy).toHaveBeenCalledWith(mockPlatformAdminUserResponse);
-      }
+      expect(isInPlatformAdminGroupSpy).toHaveBeenCalled;
+      expect(isInPlatformAdminGroupSpy).toHaveBeenCalledWith(mockPlatformAdminUserResponse);
       expect(policyResult.result).toBe(expected);
     },
   );
@@ -95,16 +93,16 @@ describe('adpPortalPermissionPolicy: Programme Admin User', () => {
     { permission: catalogEntityRefreshPermission, expected: AuthorizeResult.ALLOW },
     { permission: catalogEntityCreatePermission, expected: AuthorizeResult.ALLOW },
     { permission: catalogEntityDeletePermission, expected: AuthorizeResult.DENY },
-    { permission: catalogLocationCreatePermission, expected: AuthorizeResult.DENY },
+    { permission: catalogLocationCreatePermission, expected: AuthorizeResult.ALLOW },
     { permission: catalogLocationDeletePermission, expected: AuthorizeResult.DENY },
   ])(
     'should allow access for permission $permission.name for the Programme Admin Role',
     async ({ permission, expected }) => {
-      
+
       isInPlatformAdminGroupSpy.mockReturnValue(false)
       isIsInProgrammeAdminGroupSpy.mockReturnValue(true)
       isIsInAdpUserGroupSpy.mockReturnValue(false)
-      
+
       let mockRbacUtilities = new RbacUtilities(mockLogger, mockRbacGroups);
       const policy = new AdpPortalPermissionPolicy(mockRbacUtilities, mockLogger);
       const request: PolicyQuery = { permission: permission };
@@ -131,16 +129,16 @@ describe('adpPortalPermissionPolicy: ADP Platform User', () => {
     { permission: catalogEntityRefreshPermission, expected: AuthorizeResult.ALLOW },
     { permission: catalogEntityCreatePermission, expected: AuthorizeResult.DENY },
     { permission: catalogEntityDeletePermission, expected: AuthorizeResult.DENY },
-    { permission: catalogLocationCreatePermission, expected: AuthorizeResult.DENY  },
+    { permission: catalogLocationCreatePermission, expected: AuthorizeResult.ALLOW },
     { permission: catalogLocationDeletePermission, expected: AuthorizeResult.DENY },
   ])(
     'should allow access for permission $permission.name for the ADP Portal User Role',
     async ({ permission, expected }) => {
-      
+
       isInPlatformAdminGroupSpy.mockReturnValue(false)
       isIsInProgrammeAdminGroupSpy.mockReturnValue(false)
       isIsInAdpUserGroupSpy.mockReturnValue(true)
-      
+
       let mockRbacUtilities = new RbacUtilities(mockLogger, mockRbacGroups);
       const policy = new AdpPortalPermissionPolicy(mockRbacUtilities, mockLogger);
       const request: PolicyQuery = { permission: permission };

--- a/app/packages/backend/src/permissions/policies/adpPortalPermissionPolicy.ts
+++ b/app/packages/backend/src/permissions/policies/adpPortalPermissionPolicy.ts
@@ -38,10 +38,6 @@ export class AdpPortalPermissionPolicy implements PermissionPolicy {
       `User: identity.type - ${user?.identity.type} User: identity.userEntityRef - ${user?.identity.userEntityRef} User: identity.ownershipEntityRefs.length - ${user?.identity.ownershipEntityRefs.length} Request: type - ${request.permission.type}; name - ${request.permission.name}; action - ${request.permission.attributes.action}`,
     );
 
-    if (isPermission(request.permission, catalogLocationCreatePermission)) {
-      return { result: AuthorizeResult.DENY };  // disable importing entities using the UI
-    }
-
     // exempting admins from permission checks
     if (user != null && this.rbacUtilites.isInPlatformAdminGroup(user)) {
       this.logger.info(`This is a platform admin user with the ad group`);
@@ -58,7 +54,8 @@ export class AdpPortalPermissionPolicy implements PermissionPolicy {
       isPermission(request.permission, catalogEntityReadPermission) ||
       isPermission(request.permission, catalogLocationReadPermission) ||
       isPermission(request.permission, catalogEntityRefreshPermission) ||
-      isPermission(request.permission, catalogLocationReadPermission)
+      isPermission(request.permission, catalogLocationReadPermission) ||
+      isPermission(request.permission, catalogLocationCreatePermission)
     ) {
       return { result: AuthorizeResult.ALLOW };
     }


### PR DESCRIPTION
# **What this PR does / why we need it**:
The purpose of this PR is to modify the existing Permission policy to grant the "create location" permission to Platform Admins. It is required for scaffolding new services. 
*Link to the relevant work items: e.g: Relates to ADO Work Item [AB#274004](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/274004) and builds on #460953 ([[link to ADO Build ID URL](https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=460953&view=results)](https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=460953&view=results))*

# **Special notes for your reviewer**
None

# Testing
Tests pass locally and in the pipeline.

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [x] This PR contains tests
- [x] Version number in [package.json](https://github.com/DEFRA/adp-portal/blob/main/app/package.json#L3) has been updated


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
