### PR TITLE
325873: Assign scaffolder permissions to programme admins role

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "private": true,
   "engines": {
     "node": "18 || 20"

--- a/app/packages/backend/src/permissions/policies/adpPortalPermissionPolicy.test.ts
+++ b/app/packages/backend/src/permissions/policies/adpPortalPermissionPolicy.test.ts
@@ -11,6 +11,11 @@ import {
 import {
   AuthorizeResult
 } from '@backstage/plugin-permission-common';
+import {
+  actionExecutePermission,
+  templateParameterReadPermission,
+  templateStepReadPermission,
+} from '@backstage/plugin-scaffolder-common/alpha';
 import { AdpPortalPermissionPolicy } from './adpPortalPermissionPolicy';
 import { RbacUtilities } from '../rbacUtilites'
 
@@ -97,6 +102,9 @@ describe('adpPortalPermissionPolicy: Programme Admin User', () => {
     { permission: catalogLocationCreatePermission, expected: AuthorizeResult.ALLOW },
     { permission: catalogLocationDeletePermission, expected: AuthorizeResult.DENY },
     { permission: adpProgrammmeCreatePermission, expected: AuthorizeResult.ALLOW },
+    { permission: actionExecutePermission, expected: AuthorizeResult.ALLOW },
+    { permission: templateParameterReadPermission, expected: AuthorizeResult.ALLOW },
+    { permission: templateStepReadPermission, expected: AuthorizeResult.ALLOW },
   ])(
     'should allow access for permission $permission.name for the Programme Admin Role',
     async ({ permission, expected }) => {
@@ -134,6 +142,9 @@ describe('adpPortalPermissionPolicy: ADP Platform User', () => {
     { permission: catalogLocationCreatePermission, expected: AuthorizeResult.ALLOW },
     { permission: catalogLocationDeletePermission, expected: AuthorizeResult.DENY },
     { permission: adpProgrammmeCreatePermission, expected: AuthorizeResult.DENY },
+    { permission: actionExecutePermission, expected: AuthorizeResult.DENY },
+    { permission: templateParameterReadPermission, expected: AuthorizeResult.DENY },
+    { permission: templateStepReadPermission, expected: AuthorizeResult.DENY },
   ])(
     'should allow access for permission $permission.name for the ADP Portal User Role',
     async ({ permission, expected }) => {

--- a/app/packages/backend/src/plugins/permission.ts
+++ b/app/packages/backend/src/plugins/permission.ts
@@ -1,24 +1,29 @@
 import { createRouter } from '@backstage/plugin-permission-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
-import { AdpPortalPermissionPolicy, RbacUtilities, RbacGroups } from '../permissions';
-import {} from '../permissions'
+import {
+  AdpPortalPermissionPolicy,
+  RbacUtilities,
+  RbacGroups,
+} from '../permissions';
 
 export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
-
   const rbacGroups: RbacGroups = {
     platformAdminsGroup: env.config.getString('rbac.platformAdminsGroup'),
     programmeAdminGroup: env.config.getString('rbac.programmeAdminGroup'),
-    adpPortalUsersGroup: env.config.getString('rbac.adpPortalUsersGroup')
-  }
+    adpPortalUsersGroup: env.config.getString('rbac.adpPortalUsersGroup'),
+  };
 
   return await createRouter({
     config: env.config,
     logger: env.logger,
     discovery: env.discovery,
-    policy: new AdpPortalPermissionPolicy(new RbacUtilities(env.logger, rbacGroups), env.logger),
+    policy: new AdpPortalPermissionPolicy(
+      new RbacUtilities(env.logger, rbacGroups),
+      env.logger,
+    ),
     identity: env.identity,
   });
 }


### PR DESCRIPTION
# **What this PR does / why we need it**:
Assigns scaffolder permissions to programme admins role. Without this users in this role are unable to access the scaffolder. [AB#325873](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/325873)

# Testing
Unit tests updated

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [x] This PR contains tests
- [x] Version number in [package.json](https://github.com/DEFRA/adp-portal/blob/main/app/package.json#L3) has been updated


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2FjdjdrNTBmM2p5c3A1aTA4ZmNvdnZnbWMxd3VocHc5ZWF2dmRiYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/8abAbOrQ9rvLG/giphy.gif)
