### PR TITLE
397668: BugFix-Edit delivery project - ADO project name check

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "private": true,
   "packageManager": "yarn@4.3.0",
   "engines": {

--- a/app/plugins/adp/src/components/DeliveryProject/api/DeliveryProjectClient.ts
+++ b/app/plugins/adp/src/components/DeliveryProject/api/DeliveryProjectClient.ts
@@ -124,6 +124,15 @@ export class DeliveryProjectClient implements DeliveryProjectApi {
   async updateDeliveryProject(
     data: UpdateDeliveryProjectRequest,
   ): Promise<DeliveryProject> {
+    try {
+      if (data.ado_project) {
+        await this.#checkIfAdoProjectExists(data.ado_project);
+      }
+    } catch (error) {
+      throw new Error(
+        'Project does not exist in the DEFRA organization ADO, please enter a valid ADO project name',
+      );
+    }
     const url = await this.getApiUrl();
     const response = await this.#sendJson('PATCH', url, data);
     return await this.#readResponse(response, asDeliveryProject);
@@ -153,17 +162,12 @@ export class DeliveryProjectClient implements DeliveryProjectApi {
   }
 
   async #checkIfAdoProjectExists(adoProjectName: string): Promise<boolean> {
-    try {
-      const url = await this.getApiUrl();
-      const response = await this.#fetchApi.fetch(
-        `${url}/adoProject/${adoProjectName}`,
-      );
-      return (
-        await this.#readResponse(response, asCheckAdoProjectExistsResponse)
-      ).exists;
-    } catch (error) {
-      throw new Error(`Failed to fetch ADO Project details`);
-    }
+    const url = await this.getApiUrl();
+    const response = await this.#fetchApi.fetch(
+      `${url}/adoProject/${adoProjectName}`,
+    );
+    return (await this.#readResponse(response, asCheckAdoProjectExistsResponse))
+      .exists;
   }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
Bug fix for Edit delivery project - ADO project name check
[AB#397668](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/397668)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests
- [x] Version number in [package.json](https://github.com/DEFRA/adp-portal/blob/main/app/package.json#L3) has been updated

# Dependency check (tick or delete)
Have you updated any related templates, repositories or dependencies for new changes? We must ensure any dependencies like Software Templates are updated to include the latest changes to be scaffolded for all services where applicable.

- [ ] ADP Software Templates? - https://github.com/DEFRA/adp-software-templates
- [ ] ADP Portal Web API? https://github.com/DEFRA/adp-portal-api

# **How does this PR make you feel**:
![gif]([https://giphy.com/)