### PR TITLE
Restrict the types of components a projects catalog info can load in.

### DIFF
--- a/app/app-config.yaml
+++ b/app/app-config.yaml
@@ -145,8 +145,17 @@ catalog:
     entityFilename: catalog-info.yaml
     pullRequestBranchName: backstage-integration
   rules:
+    - allow: [Component, API, Resource]
+      locations:
+        - type: url
+          pattern: 'https://github.com/${GITHUB_ORGANIZATION}/**/catalog-info.yaml'
+
     - allow:
-        [Component, System, API, Resource, Location, Template, Domain, Group]
+        [Component, API, Resource, System, Location, Template, Domain, Group]
+      locations:
+        - type: url
+          pattern: 'https://github.com/DEFRA/adp-software-templates/**'
+
   processingInterval: { minutes: 60 }
 
   # Providers configured to scan repos in the specified organizations for components to add to the catalog.

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "private": true,
   "packageManager": "yarn@4.3.1",
   "engines": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "private": true,
   "packageManager": "yarn@4.3.1",
   "engines": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
Restrict what catalog entity types a location can load in.
- adp-software-templates can load in any entity type
- catalog-info.yaml from any repo can load in components, apis and resources

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# **How does this PR make you feel**:
![gif]([https://giphy.com/)