### PR TITLE
Fix warnings from backstage 0.28 & sonarcloud

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.6.17",
+  "version": "1.7.0",
   "private": true,
   "packageManager": "yarn@4.3.1",
   "engines": {

--- a/app/packages/backend/package.json
+++ b/app/packages/backend/package.json
@@ -60,7 +60,6 @@
     "express-promise-router": "^4.1.0",
     "node-gyp": "^9.0.0",
     "pg": "^8.11.3",
-    "winston": "^3.2.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/app/plugins/adp-backend/package.json
+++ b/app/plugins/adp-backend/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.23.2",
+    "@backstage/backend-defaults": "^0.3.3",
     "@backstage/backend-plugin-api": "^0.6.21",
     "@backstage/catalog-client": "^1.6.5",
     "@backstage/catalog-model": "^1.5.0",

--- a/app/plugins/adp-backend/src/database/initializeAdpDatabase.ts
+++ b/app/plugins/adp-backend/src/database/initializeAdpDatabase.ts
@@ -1,5 +1,5 @@
-import type { PluginDatabaseManager } from '@backstage/backend-common';
-import { resolvePackagePath } from '@backstage/backend-common';
+import type { DatabaseService } from '@backstage/backend-plugin-api';
+import { resolvePackagePath } from '@backstage/backend-plugin-api';
 
 const migrationsDir = resolvePackagePath(
   '@internal/plugin-adp-backend',
@@ -8,7 +8,7 @@ const migrationsDir = resolvePackagePath(
 
 const seedDir = resolvePackagePath('@internal/plugin-adp-backend', 'seedData');
 
-export async function initializeAdpDatabase(database: PluginDatabaseManager) {
+export async function initializeAdpDatabase(database: DatabaseService) {
   if (database.migrations?.skip) return;
 
   const client = await database.getClient();

--- a/app/plugins/adp-backend/src/deliveryProgrammeAdmin/deliveryProgrammeAdminStore.test.ts
+++ b/app/plugins/adp-backend/src/deliveryProgrammeAdmin/deliveryProgrammeAdminStore.test.ts
@@ -11,10 +11,7 @@ import { arms_length_body_name } from '../armsLengthBody/arms_length_body';
 import { albSeedData } from '../testData/albTestData';
 import type { Knex } from 'knex';
 import { deliveryProgrammeSeedData } from '../testData/programmeTestData';
-import {
-  createDeliveryProgrammeAdmin,
-  createDeliveryProgrammeAdminEntity,
-} from '../testData/programmeAdminTestData';
+import { createDeliveryProgrammeAdmin } from '../testData/programmeAdminTestData';
 import { faker } from '@faker-js/faker';
 import { assertUUID } from '../service/util';
 
@@ -46,7 +43,7 @@ describe('DeliveryProgrammeAdminStore', () => {
 
   async function seedProgrammeAdmin(knex: Knex) {
     const programmeId = await seedProgramme(knex);
-    const programmeAdmin = createDeliveryProgrammeAdminEntity(programmeId);
+    const programmeAdmin = createDeliveryProgrammeAdmin(programmeId);
     await knex<delivery_programme_admin>(delivery_programme_admin_name).insert(
       programmeAdmin,
     );
@@ -72,7 +69,7 @@ describe('DeliveryProgrammeAdminStore', () => {
         await createDatabase(databaseId);
       const programmeId = await seedProgramme(knex);
       const programmeAdmins = faker.helpers.multiple(
-        () => createDeliveryProgrammeAdminEntity(programmeId),
+        () => createDeliveryProgrammeAdmin(programmeId),
         { count: 4 },
       );
       await knex<delivery_programme_admin>(
@@ -92,7 +89,7 @@ describe('DeliveryProgrammeAdminStore', () => {
       const { deliveryProgrammeAdminStore, knex } =
         await createDatabase(databaseId);
       const programmeId = await seedProgramme(knex);
-      const programmeAdmin = createDeliveryProgrammeAdminEntity(programmeId);
+      const programmeAdmin = createDeliveryProgrammeAdmin(programmeId);
       await knex<delivery_programme_admin>(
         delivery_programme_admin_name,
       ).insert(programmeAdmin);

--- a/app/plugins/adp-backend/src/plugin.test.ts
+++ b/app/plugins/adp-backend/src/plugin.test.ts
@@ -8,7 +8,7 @@ describe('adpPlugin', () => {
     const { server } = await startTestBackend({
       extensionPoints: [],
       features: [
-        adpPlugin(),
+        adpPlugin,
         mockServices.logger.factory(),
         mockServices.discovery.factory(),
         mockServices.database.factory(),

--- a/app/plugins/adp-backend/src/plugin.ts
+++ b/app/plugins/adp-backend/src/plugin.ts
@@ -1,3 +1,4 @@
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import {
   coreServices,
   createBackendPlugin,
@@ -78,6 +79,7 @@ export const adpPlugin = createBackendPlugin({
         tokens,
       }) {
         await initializeAdpDatabase(database);
+        const middleware = MiddlewareFactory.create({ config, logger });
 
         const dbClient = await database.getClient();
         const armsLengthBodyStore = new ArmsLengthBodyStore(dbClient);
@@ -174,6 +176,7 @@ export const adpPlugin = createBackendPlugin({
             config,
             httpAuth,
             permissions,
+            middleware,
           }),
         );
         combinedRouter.use(
@@ -188,6 +191,7 @@ export const adpPlugin = createBackendPlugin({
             permissions,
             auth,
             catalog,
+            middleware,
           }),
         );
         combinedRouter.use(
@@ -204,6 +208,7 @@ export const adpPlugin = createBackendPlugin({
             adoProjectApi,
             httpAuth,
             permissions,
+            middleware,
           }),
         );
         combinedRouter.use(
@@ -216,6 +221,7 @@ export const adpPlugin = createBackendPlugin({
             permissions,
             httpAuth,
             auth,
+            middleware,
           }),
         );
         combinedRouter.use(
@@ -229,6 +235,7 @@ export const adpPlugin = createBackendPlugin({
             permissions,
             auth,
             httpAuth,
+            middleware,
           }),
         );
 

--- a/app/plugins/adp-backend/src/service/armsLengthBodyRouter.test.ts
+++ b/app/plugins/adp-backend/src/service/armsLengthBodyRouter.test.ts
@@ -1,3 +1,4 @@
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import express from 'express';
 import request from 'supertest';
 import type { AlbRouterOptions } from './armsLengthBodyRouter';
@@ -47,15 +48,19 @@ describe('createRouter', () => {
   const mockOptions: AlbRouterOptions = {
     logger: mockServices.logger.mock(),
     identity: mockIdentityApi,
-    config: mockConfig,
     armsLengthBodyStore: mockArmsLengthBodyStore,
     deliveryProgrammeStore: mockDeliveryProgrammeStore,
     httpAuth: mockServices.httpAuth(),
     permissions: mockPermissionsService,
+    config: mockConfig,
+    middleware: MiddlewareFactory.create({
+      config: mockConfig,
+      logger: mockServices.logger.mock(),
+    }),
   };
 
   beforeAll(async () => {
-    const router = await createAlbRouter(mockOptions);
+    const router = createAlbRouter(mockOptions);
     app = express().use(router);
   });
 

--- a/app/plugins/adp-backend/src/service/armsLengthBodyRouter.ts
+++ b/app/plugins/adp-backend/src/service/armsLengthBodyRouter.ts
@@ -1,4 +1,4 @@
-import { errorHandler } from '@backstage/backend-common';
+import type { MiddlewareFactory } from '@backstage/backend-defaults/dist/rootHttpRouter';
 import express from 'express';
 import Router from 'express-promise-router';
 import { InputError } from '@backstage/errors';
@@ -27,9 +27,10 @@ export interface AlbRouterOptions {
   identity: IdentityApi;
   armsLengthBodyStore: IArmsLengthBodyStore;
   deliveryProgrammeStore: IDeliveryProgrammeStore;
-  config: Config;
   permissions: PermissionsService;
   httpAuth: HttpAuthService;
+  middleware: MiddlewareFactory;
+  config: Config;
 }
 
 const errorMapping = {
@@ -82,9 +83,11 @@ export function createAlbRouter(options: AlbRouterOptions): express.Router {
     deliveryProgrammeStore,
     permissions,
     httpAuth,
+    config,
+    middleware,
   } = options;
 
-  const owner = getOwner(options);
+  const owner = getOwner(config);
 
   const router = Router();
   router.use(express.json());
@@ -176,6 +179,6 @@ export function createAlbRouter(options: AlbRouterOptions): express.Router {
     const result = await armsLengthBodyStore.update(body, creator);
     respond(body, res, result, errorMapping);
   });
-  router.use(errorHandler());
+  router.use(middleware.error());
   return router;
 }

--- a/app/plugins/adp-backend/src/service/deliveryProgrammeAdminRouter.test.ts
+++ b/app/plugins/adp-backend/src/service/deliveryProgrammeAdminRouter.test.ts
@@ -1,3 +1,4 @@
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import express from 'express';
 import request from 'supertest';
 import { programmeManagerList } from '../testData/programmeTestData';
@@ -64,6 +65,10 @@ describe('createRouter', () => {
     permissions: mockPermissionsService,
     httpAuth: mockServices.httpAuth(),
     auth: mockServices.auth(),
+    middleware: MiddlewareFactory.create({
+      config: mockServices.rootConfig(),
+      logger: mockServices.logger.mock(),
+    }),
   };
 
   beforeAll(() => {

--- a/app/plugins/adp-backend/src/service/deliveryProgrammeAdminRouter.ts
+++ b/app/plugins/adp-backend/src/service/deliveryProgrammeAdminRouter.ts
@@ -1,4 +1,4 @@
-import { errorHandler } from '@backstage/backend-common';
+import type { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import { type IdentityApi } from '@backstage/plugin-auth-node';
 import type { IDeliveryProgrammeAdminStore } from '../deliveryProgrammeAdmin';
 import express from 'express';
@@ -75,6 +75,7 @@ export interface DeliveryProgrammeAdminRouterOptions {
   permissions: PermissionsService;
   httpAuth: HttpAuthService;
   auth: AuthService;
+  middleware: MiddlewareFactory;
 }
 
 export function createDeliveryProgrammeAdminRouter(
@@ -87,6 +88,7 @@ export function createDeliveryProgrammeAdminRouter(
     permissions,
     httpAuth,
     auth,
+    middleware,
   } = options;
 
   const router = Router();
@@ -199,6 +201,6 @@ export function createDeliveryProgrammeAdminRouter(
     res.status(204).end();
   });
 
-  router.use(errorHandler());
+  router.use(middleware.error());
   return router;
 }

--- a/app/plugins/adp-backend/src/service/deliveryProgrammeRouter.test.ts
+++ b/app/plugins/adp-backend/src/service/deliveryProgrammeRouter.test.ts
@@ -1,3 +1,4 @@
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import express from 'express';
 import request from 'supertest';
 import type { ProgrammeRouterOptions } from './deliveryProgrammeRouter';
@@ -87,6 +88,10 @@ describe('createRouter', () => {
     httpAuth: mockServices.httpAuth(),
     catalog: mockCatalogClient,
     auth: mockServices.auth(),
+    middleware: MiddlewareFactory.create({
+      config: mockServices.rootConfig(),
+      logger: mockServices.logger.mock(),
+    }),
   };
 
   beforeAll(async () => {

--- a/app/plugins/adp-backend/src/service/deliveryProgrammeRouter.ts
+++ b/app/plugins/adp-backend/src/service/deliveryProgrammeRouter.ts
@@ -1,4 +1,4 @@
-import { errorHandler } from '@backstage/backend-common';
+import type { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import express from 'express';
 import Router from 'express-promise-router';
 import { InputError } from '@backstage/errors';
@@ -41,6 +41,7 @@ export interface ProgrammeRouterOptions {
   httpAuth: HttpAuthService;
   auth: AuthService;
   permissions: PermissionsService;
+  middleware: MiddlewareFactory;
 }
 
 const errorMapping = {
@@ -131,6 +132,7 @@ export function createProgrammeRouter(
     httpAuth,
     auth,
     permissions,
+    middleware,
   } = options;
 
   const router = Router();
@@ -248,6 +250,6 @@ export function createProgrammeRouter(
     respond(body, res, result, errorMapping);
   });
 
-  router.use(errorHandler());
+  router.use(middleware.error());
   return router;
 }

--- a/app/plugins/adp-backend/src/service/deliveryProjectRouter.test.ts
+++ b/app/plugins/adp-backend/src/service/deliveryProjectRouter.test.ts
@@ -1,3 +1,4 @@
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import express from 'express';
 import request from 'supertest';
 import type { ProjectRouterOptions } from './deliveryProjectRouter';
@@ -127,6 +128,10 @@ describe('createRouter', () => {
     adoProjectApi: mockAdoProjectApi,
     httpAuth: mockServices.httpAuth(),
     permissions: mockPermissionsService,
+    middleware: MiddlewareFactory.create({
+      config: mockServices.rootConfig(),
+      logger: mockServices.logger.mock(),
+    }),
   };
 
   beforeAll(() => {

--- a/app/plugins/adp-backend/src/service/deliveryProjectRouter.ts
+++ b/app/plugins/adp-backend/src/service/deliveryProjectRouter.ts
@@ -1,4 +1,4 @@
-import { errorHandler } from '@backstage/backend-common';
+import type { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import express from 'express';
 import Router from 'express-promise-router';
 import { InputError } from '@backstage/errors';
@@ -39,6 +39,7 @@ export interface ProjectRouterOptions {
   adoProjectApi: IAdoProjectApi;
   permissions: PermissionsService;
   httpAuth: HttpAuthService;
+  middleware: MiddlewareFactory;
 }
 
 const errorMapping = {
@@ -135,6 +136,7 @@ export function createProjectRouter(
     adoProjectApi,
     httpAuth,
     permissions,
+    middleware,
   } = options;
 
   const router = Router();
@@ -260,6 +262,6 @@ export function createProjectRouter(
     }
   });
 
-  router.use(errorHandler());
+  router.use(middleware.error());
   return router;
 }

--- a/app/plugins/adp-backend/src/service/deliveryProjectUserRouter.test.ts
+++ b/app/plugins/adp-backend/src/service/deliveryProjectUserRouter.test.ts
@@ -1,3 +1,4 @@
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import express from 'express';
 import request from 'supertest';
 import type { IDeliveryProjectUserStore } from '../deliveryProjectUser';
@@ -73,6 +74,10 @@ describe('createRouter', () => {
     permissions: mockPermissionsService,
     httpAuth: mockServices.httpAuth(),
     auth: mockServices.auth(),
+    middleware: MiddlewareFactory.create({
+      config: mockServices.rootConfig(),
+      logger: mockServices.logger.mock(),
+    }),
   };
 
   beforeAll(() => {

--- a/app/plugins/adp-backend/src/service/deliveryProjectUserRouter.ts
+++ b/app/plugins/adp-backend/src/service/deliveryProjectUserRouter.ts
@@ -2,7 +2,7 @@ import type { IDeliveryProjectUserStore } from '../deliveryProjectUser';
 import type { CatalogApi } from '@backstage/catalog-client';
 import express from 'express';
 import Router from 'express-promise-router';
-import { errorHandler } from '@backstage/backend-common';
+import type { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import { assertUUID, checkPermissions, createParser, respond } from './util';
 import {
   type CreateDeliveryProjectUserRequest,
@@ -93,6 +93,7 @@ export interface DeliveryProjectUserRouterOptions {
   permissions: PermissionsService;
   httpAuth: HttpAuthService;
   auth: AuthService;
+  middleware: MiddlewareFactory;
 }
 
 export function createDeliveryProjectUserRouter(
@@ -106,6 +107,7 @@ export function createDeliveryProjectUserRouter(
     permissions,
     httpAuth,
     auth,
+    middleware,
   } = options;
 
   const router = Router();
@@ -272,6 +274,6 @@ export function createDeliveryProjectUserRouter(
     res.status(204).end();
   });
 
-  router.use(errorHandler());
+  router.use(middleware.error());
   return router;
 }

--- a/app/plugins/adp-backend/src/testData/programmeAdminTestData.ts
+++ b/app/plugins/adp-backend/src/testData/programmeAdminTestData.ts
@@ -3,9 +3,7 @@ import type { delivery_programme_admin } from '../deliveryProgrammeAdmin/deliver
 import { assertUUID } from '../service/util';
 import type { DeliveryProgrammeAdmin } from '@internal/plugin-adp-common';
 
-export function createDeliveryProgrammeAdminEntity(
-  deliveryProgrammeId: string,
-): delivery_programme_admin {
+export function createDeliveryProgrammeAdmin(deliveryProgrammeId: string) {
   const firstName = faker.person.firstName();
   const lastName = faker.person.lastName();
   const entityId = faker.string.uuid();
@@ -20,27 +18,7 @@ export function createDeliveryProgrammeAdminEntity(
     id: entityId,
     name: faker.person.fullName({ firstName: firstName, lastName: lastName }),
     updated_at: faker.date.past(),
-  };
-}
-
-export function createDeliveryProgrammeAdmin(
-  deliveryProgrammeId: string,
-): DeliveryProgrammeAdmin {
-  const firstName = faker.person.firstName();
-  const lastName = faker.person.lastName();
-  const entityId = faker.string.uuid();
-
-  assertUUID(deliveryProgrammeId);
-  assertUUID(entityId);
-
-  return {
-    aad_entity_ref_id: faker.string.uuid(),
-    delivery_programme_id: deliveryProgrammeId,
-    email: faker.internet.email({ firstName: firstName, lastName: lastName }),
-    id: entityId,
-    name: faker.person.fullName({ firstName: firstName, lastName: lastName }),
-    updated_at: faker.date.past(),
-  };
+  } satisfies DeliveryProgrammeAdmin satisfies delivery_programme_admin;
 }
 
 export const expectedProgrammeAdmin = {

--- a/app/plugins/adp-backend/src/utils/index.ts
+++ b/app/plugins/adp-backend/src/utils/index.ts
@@ -1,7 +1,7 @@
 import type { DeliveryProject } from '@internal/plugin-adp-common';
 import type { IdentityApi } from '@backstage/plugin-auth-node';
 import type express from 'express';
-import type { AlbRouterOptions } from '../service/armsLengthBodyRouter';
+import type { Config } from '@backstage/config';
 
 export * from './types';
 
@@ -13,8 +13,7 @@ export async function getCurrentUsername(
   return user?.identity.userEntityRef ?? 'unknown';
 }
 
-export function getOwner(options: AlbRouterOptions): string {
-  const { config } = options;
+export function getOwner(config: Config): string {
   const ownerGroup = config.getConfig('rbac');
   const owner = ownerGroup.getString('programmeAdminGroup');
   return owner;

--- a/app/plugins/catalog-backend-module-adp/src/module.test.ts
+++ b/app/plugins/catalog-backend-module-adp/src/module.test.ts
@@ -49,7 +49,7 @@ describe('catalogModuleAdpEntityProvider', () => {
         ],
       ],
       features: [
-        adpCatalogModule(),
+        adpCatalogModule,
         discovery.factory,
         mockServices.logger.factory(),
         mockServices.scheduler.factory(),

--- a/app/plugins/catalog-backend-module-adp/src/providers/AdpDatabaseEntityProvider.test.ts
+++ b/app/plugins/catalog-backend-module-adp/src/providers/AdpDatabaseEntityProvider.test.ts
@@ -1,10 +1,10 @@
-import type { TaskRunner } from '@backstage/backend-tasks';
 import { AdpDatabaseEntityProvider } from './AdpDatabaseEntityProvider';
 import type { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import type {
   AuthService,
   DiscoveryService,
   SchedulerService,
+  SchedulerServiceTaskRunner,
 } from '@backstage/backend-plugin-api';
 import type { FetchApi } from '@internal/plugin-fetch-api-backend';
 import type * as AdpDatabaseEntityProviderConnection from './AdpDatabaseEntityProviderConnection';
@@ -60,7 +60,7 @@ describe('AdpDatabaseEntityProvider', () => {
       getBaseUrl: jest.fn().mockResolvedValue('http://localhost:123/api/adp'),
       getExternalBaseUrl: jest.fn(),
     };
-    const schedule: jest.Mocked<TaskRunner> = {
+    const schedule: jest.Mocked<SchedulerServiceTaskRunner> = {
       run: jest.fn(),
     };
     const scheduler: jest.Mocked<SchedulerService> = {

--- a/app/plugins/catalog-backend-module-adp/src/providers/AdpDatabaseEntityProvider.ts
+++ b/app/plugins/catalog-backend-module-adp/src/providers/AdpDatabaseEntityProvider.ts
@@ -1,4 +1,3 @@
-import type { TaskRunner, PluginTaskScheduler } from '@backstage/backend-tasks';
 import type {
   EntityProvider,
   EntityProviderConnection,
@@ -8,13 +7,15 @@ import type {
   AuthService,
   DiscoveryService,
   LoggerService,
+  SchedulerService,
+  SchedulerServiceTaskRunner,
 } from '@backstage/backend-plugin-api';
 import type { FetchApi } from '@internal/plugin-fetch-api-backend';
 import { AdpDatabaseEntityProviderConnection } from './AdpDatabaseEntityProviderConnection';
 
 export class AdpDatabaseEntityProvider implements EntityProvider {
   readonly #logger: LoggerService;
-  readonly #taskRunner: TaskRunner;
+  readonly #taskRunner: SchedulerServiceTaskRunner;
   readonly #discovery: DiscoveryService;
   readonly #fetchApi: FetchApi;
   readonly #auth: AuthService;
@@ -28,8 +29,8 @@ export class AdpDatabaseEntityProvider implements EntityProvider {
     discovery: DiscoveryService;
     logger: LoggerService;
     fetchApi: FetchApi;
-    schedule?: TaskRunner;
-    scheduler?: PluginTaskScheduler;
+    schedule?: SchedulerServiceTaskRunner;
+    scheduler?: SchedulerService;
     auth: AuthService;
   }) {
     const defaultSchedule = {
@@ -57,7 +58,7 @@ export class AdpDatabaseEntityProvider implements EntityProvider {
   private constructor(
     logger: LoggerService,
     discovery: DiscoveryService,
-    taskRunner: TaskRunner,
+    taskRunner: SchedulerServiceTaskRunner,
     fetchApi: FetchApi,
     auth: AuthService,
   ) {

--- a/app/plugins/catalog-backend-module-adp/src/providers/AdpDatabaseEntityProviderConnection.test.ts
+++ b/app/plugins/catalog-backend-module-adp/src/providers/AdpDatabaseEntityProviderConnection.test.ts
@@ -1,5 +1,3 @@
-import { getVoidLogger } from '@backstage/backend-common';
-import type { TaskRunner } from '@backstage/backend-tasks';
 import { AdpDatabaseEntityProvider } from './AdpDatabaseEntityProvider';
 import type { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import type {
@@ -8,6 +6,7 @@ import type {
   BackstageServicePrincipal,
   DiscoveryService,
   SchedulerService,
+  SchedulerServiceTaskRunner,
 } from '@backstage/backend-plugin-api';
 import type { FetchApi } from '@internal/plugin-fetch-api-backend';
 import { AdpDatabaseEntityProviderConnection } from './AdpDatabaseEntityProviderConnection';
@@ -20,10 +19,11 @@ import {
   mockProgrammeTransformerData,
   mockProjectTransformerData,
 } from '../testData/entityProviderTestData';
+import { mockServices } from '@backstage/backend-test-utils';
 
 describe('AdpDatabaseEntityProviderConnection', () => {
   function setup() {
-    const logger = getVoidLogger();
+    const logger = mockServices.logger.mock();
     const fetchApi: jest.Mocked<FetchApi> = {
       fetch: jest.fn(),
     };
@@ -40,7 +40,7 @@ describe('AdpDatabaseEntityProviderConnection', () => {
       getBaseUrl: jest.fn().mockResolvedValue('http://localhost:123/api/adp'),
       getExternalBaseUrl: jest.fn(),
     };
-    const schedule: jest.Mocked<TaskRunner> = {
+    const schedule: jest.Mocked<SchedulerServiceTaskRunner> = {
       run: jest.fn(),
     };
     const scheduler: jest.Mocked<SchedulerService> = {

--- a/app/plugins/catalog-backend-module-adp/src/transformers/defraUserNameTransformer.test.ts
+++ b/app/plugins/catalog-backend-module-adp/src/transformers/defraUserNameTransformer.test.ts
@@ -1,6 +1,6 @@
 import { defraUserNameTransformer } from './defraUserNameTransformer';
-import { defaultUserTransformer } from '@backstage/plugin-catalog-backend-module-msgraph';
 import {
+  defaultUserTransformer,
   MICROSOFT_EMAIL_ANNOTATION,
   MICROSOFT_GRAPH_USER_ID_ANNOTATION,
 } from '@backstage/plugin-catalog-backend-module-msgraph';

--- a/app/plugins/catalog-backend-module-adp/src/transformers/defraUserNameTransformer.ts
+++ b/app/plugins/catalog-backend-module-adp/src/transformers/defraUserNameTransformer.ts
@@ -7,7 +7,7 @@ import {
 } from '@backstage/plugin-catalog-backend-module-msgraph';
 
 function hasEmailOrUserPrincipalName(user: MicrosoftGraph.User) {
-  return user.mail || user.userPrincipalName;
+  return user.mail ? user.mail : user.userPrincipalName;
 }
 
 function createEntityFromOriginalUser(

--- a/app/plugins/fetch-api-backend/src/ref/fetchApiRef.test.ts
+++ b/app/plugins/fetch-api-backend/src/ref/fetchApiRef.test.ts
@@ -5,7 +5,7 @@ describe('fetchApiRef', () => {
     expect(fetchApiRef.id).toBe('fetch-api');
     expect(fetchApiRef.scope).toBe('plugin');
     expect(fetchApiRef.$$type).toBe('@backstage/ServiceRef');
-    expect(fetchApiRef.toString()).toBe('serviceRef{fetch-api}');
+    expect(String(fetchApiRef)).toBe('serviceRef{fetch-api}');
     expect(() => fetchApiRef.T).toThrow();
     expect(fetchApiRef).toHaveProperty('__defaultFactory', undefined);
   });

--- a/app/plugins/fetch-api-backend/src/ref/rootFetchApiRef.test.ts
+++ b/app/plugins/fetch-api-backend/src/ref/rootFetchApiRef.test.ts
@@ -5,7 +5,7 @@ describe('fetchApiRef', () => {
     expect(rootFetchApiRef.id).toBe('fetch-api.root');
     expect(rootFetchApiRef.scope).toBe('root');
     expect(rootFetchApiRef.$$type).toBe('@backstage/ServiceRef');
-    expect(rootFetchApiRef.toString()).toBe('serviceRef{fetch-api.root}');
+    expect(String(rootFetchApiRef)).toBe('serviceRef{fetch-api.root}');
     expect(() => rootFetchApiRef.T).toThrow();
     expect(rootFetchApiRef).toHaveProperty('__defaultFactory', undefined);
   });

--- a/app/plugins/permission-backend-module-adp/src/policies/adpPortalPermissionPolicy.test.ts
+++ b/app/plugins/permission-backend-module-adp/src/policies/adpPortalPermissionPolicy.test.ts
@@ -1,6 +1,5 @@
 import { AdpPortalPermissionPolicy } from './adpPortalPermissionPolicy';
 import { RbacUtilities } from '../rbacUtilites';
-import { getVoidLogger } from '@backstage/backend-common';
 import type { RbacGroups } from '../types';
 import {
   catalogEntityReadPermission,
@@ -29,6 +28,7 @@ import {
   templateParameterReadPermission,
   templateStepReadPermission,
 } from '@backstage/plugin-scaffolder-common/alpha';
+import { mockServices } from '@backstage/backend-test-utils';
 
 describe('adpPortalPermissionPolicy', () => {
   function setup() {
@@ -37,9 +37,15 @@ describe('adpPortalPermissionPolicy', () => {
       programmeAdminGroup: 'Test-ProgrammeAdminGroup',
       adpPortalUsersGroup: 'Test-AdpPortalUsersGroup',
     };
-    const rbacUtilities = new RbacUtilities(getVoidLogger(), rbacGroups);
+    const rbacUtilities = new RbacUtilities(
+      mockServices.logger.mock(),
+      rbacGroups,
+    );
 
-    const sut = new AdpPortalPermissionPolicy(rbacUtilities, getVoidLogger());
+    const sut = new AdpPortalPermissionPolicy(
+      rbacUtilities,
+      mockServices.logger.mock(),
+    );
 
     return { sut, rbacGroups };
   }

--- a/app/plugins/scaffolder-backend-module-adp/src/actions/azure-devops/AzureDevOpsApi.test.ts
+++ b/app/plugins/scaffolder-backend-module-adp/src/actions/azure-devops/AzureDevOpsApi.test.ts
@@ -2,7 +2,7 @@ import { ConfigReader } from '@backstage/config';
 import { ScmIntegrations } from '@backstage/integration';
 import { RestClient } from 'typed-rest-client';
 import { AzureDevOpsApi } from './AzureDevOpsApi';
-import { getVoidLogger } from '@backstage/backend-common';
+import { mockServices } from '@backstage/backend-test-utils';
 import { BuildResult, BuildStatus } from './types';
 
 jest.mock('azure-devops-node-api', () => ({
@@ -50,7 +50,7 @@ describe('AzureDevOpsApi', () => {
         integrations,
         config,
         { server: 'test.azure.com', organization: 'another-test-org' },
-        { logger: getVoidLogger() },
+        { logger: mockServices.logger.mock() },
       ),
     ).rejects.toThrow(/No credentials provided/);
   });
@@ -60,7 +60,7 @@ describe('AzureDevOpsApi', () => {
       integrations,
       config,
       { server: 'dev.azure.com', organization: 'org' },
-      { logger: getVoidLogger() },
+      { logger: mockServices.logger.mock() },
     );
 
     expect(adoApi).toBeDefined();
@@ -79,7 +79,7 @@ describe('AzureDevOpsApi:getServiceConnections', () => {
         integrations,
         config,
         { server: 'dev.azure.com', organization: 'org' },
-        { logger: getVoidLogger() },
+        { logger: mockServices.logger.mock() },
       );
 
       await expect(
@@ -109,7 +109,7 @@ describe('AzureDevOpsApi:getServiceConnections', () => {
       integrations,
       config,
       { server: 'dev.azure.com', organization: 'org' },
-      { logger: getVoidLogger() },
+      { logger: mockServices.logger.mock() },
     );
 
     await adoApi.getServiceConnections(
@@ -150,7 +150,7 @@ describe('AzureDevOpsApi:getServiceConnections', () => {
       integrations,
       config,
       { server: 'dev.azure.com', organization: 'org' },
-      { logger: getVoidLogger() },
+      { logger: mockServices.logger.mock() },
     );
 
     const serviceConnections = await adoApi.getServiceConnections(
@@ -181,7 +181,7 @@ describe('AzureDevOpsApi:createPipeline', () => {
         integrations,
         config,
         { server: 'dev.azure.com', organization: 'org' },
-        { logger: getVoidLogger() },
+        { logger: mockServices.logger.mock() },
       );
 
       await expect(
@@ -218,7 +218,7 @@ describe('AzureDevOpsApi:createPipeline', () => {
       integrations,
       config,
       { server: 'dev.azure.com', organization: 'org' },
-      { logger: getVoidLogger() },
+      { logger: mockServices.logger.mock() },
     );
 
     await adoApi.createPipeline(
@@ -266,7 +266,7 @@ describe('AzureDevOpsApi:createPipeline', () => {
       integrations,
       config,
       { server: 'dev.azure.com', organization: 'org' },
-      { logger: getVoidLogger() },
+      { logger: mockServices.logger.mock() },
     );
 
     const pipeline = await adoApi.createPipeline(
@@ -299,7 +299,7 @@ describe('AzureDevOpsApi:permitPipeline', () => {
         integrations,
         config,
         { server: 'dev.azure.com', organization: 'org' },
-        { logger: getVoidLogger() },
+        { logger: mockServices.logger.mock() },
       );
 
       await expect(
@@ -328,7 +328,7 @@ describe('AzureDevOpsApi:permitPipeline', () => {
       integrations,
       config,
       { server: 'dev.azure.com', organization: 'org' },
-      { logger: getVoidLogger() },
+      { logger: mockServices.logger.mock() },
     );
 
     await adoApi.permitPipeline(
@@ -373,7 +373,7 @@ describe('AzureDevOpsApi:runPipeline', () => {
         integrations,
         config,
         { server: 'dev.azure.com', organization: 'org' },
-        { logger: getVoidLogger() },
+        { logger: mockServices.logger.mock() },
       );
 
       await expect(
@@ -401,7 +401,7 @@ describe('AzureDevOpsApi:runPipeline', () => {
       integrations,
       config,
       { server: 'dev.azure.com', organization: 'org' },
-      { logger: getVoidLogger() },
+      { logger: mockServices.logger.mock() },
     );
 
     await adoApi.runPipeline({ organization: 'org', project: 'project' }, 1234);
@@ -451,7 +451,7 @@ describe('AzureDevOpsApi:runPipeline', () => {
       integrations,
       config,
       { server: 'dev.azure.com', organization: 'org' },
-      { logger: getVoidLogger() },
+      { logger: mockServices.logger.mock() },
     );
 
     const pipeline = await adoApi.runPipeline(
@@ -480,7 +480,7 @@ describe('AzureDevOpsApi:getBuild', () => {
         integrations,
         config,
         { server: 'dev.azure.com', organization: 'org' },
-        { logger: getVoidLogger() },
+        { logger: mockServices.logger.mock() },
       );
 
       await expect(
@@ -506,7 +506,7 @@ describe('AzureDevOpsApi:getBuild', () => {
       integrations,
       config,
       { server: 'dev.azure.com', organization: 'org' },
-      { logger: getVoidLogger() },
+      { logger: mockServices.logger.mock() },
     );
 
     await adoApi.runPipeline({ organization: 'org', project: 'project' }, 1234);
@@ -543,7 +543,7 @@ describe('AzureDevOpsApi:getBuild', () => {
       integrations,
       config,
       { server: 'dev.azure.com', organization: 'org' },
-      { logger: getVoidLogger() },
+      { logger: mockServices.logger.mock() },
     );
 
     const pipeline = await adoApi.getBuild(

--- a/app/plugins/scaffolder-backend-module-adp/src/actions/azure-devops/AzureDevOpsApi.ts
+++ b/app/plugins/scaffolder-backend-module-adp/src/actions/azure-devops/AzureDevOpsApi.ts
@@ -8,7 +8,7 @@ import {
 } from 'azure-devops-node-api';
 import type { IRequestOptions, IRestResponse } from 'typed-rest-client';
 import { RestClient } from 'typed-rest-client';
-import type { Logger } from 'winston';
+import type { LoggerService } from '@backstage/backend-plugin-api';
 import type {
   Build,
   Pipeline,
@@ -64,9 +64,9 @@ type RunPipelineRequest = {
 export class AzureDevOpsApi {
   private readonly restClient: RestClient;
   private readonly requestOptions: IRequestOptions;
-  private readonly logger: Logger;
+  private readonly logger: LoggerService;
 
-  private constructor(restClient: RestClient, logger: Logger) {
+  private constructor(restClient: RestClient, logger: LoggerService) {
     this.restClient = restClient;
     this.logger = logger;
     this.requestOptions = {
@@ -78,7 +78,7 @@ export class AzureDevOpsApi {
     scmIntegrations: ScmIntegrationRegistry,
     config: Config,
     azureDevOpsOptions: { server: string; organization: string },
-    options: { logger: Logger },
+    options: { logger: LoggerService },
   ): Promise<AzureDevOpsApi> {
     const encodedOrganization = encodeURIComponent(
       azureDevOpsOptions.organization,

--- a/app/plugins/scaffolder-backend-module-adp/src/actions/azure-devops/runPipeline.ts
+++ b/app/plugins/scaffolder-backend-module-adp/src/actions/azure-devops/runPipeline.ts
@@ -3,7 +3,7 @@ import { InputError } from '@backstage/errors';
 import type { ScmIntegrationRegistry } from '@backstage/integration';
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { BuildStatus } from './types';
-import type { Logger } from 'winston';
+import type { LoggerService } from '@backstage/backend-plugin-api';
 import { AzureDevOpsApi } from './AzureDevOpsApi';
 
 export type RunPipelineActionInput = {
@@ -148,7 +148,7 @@ async function checkPipelineStatus(
   organization: string,
   project: string,
   runId: number,
-  logger: Logger,
+  logger: LoggerService,
   apiVersion?: string,
 ): Promise<boolean> {
   const build = await adoApi.getBuild(

--- a/app/plugins/scaffolder-backend-module-adp/src/actions/github/addDeliveryProjectToRepo.ts
+++ b/app/plugins/scaffolder-backend-module-adp/src/actions/github/addDeliveryProjectToRepo.ts
@@ -1,4 +1,4 @@
-import type { Logger } from 'winston';
+import type { LoggerService } from '@backstage/backend-plugin-api';
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import type { Octokit } from 'octokit';
 import type { Config } from '@backstage/config';
@@ -69,7 +69,7 @@ export function addDeliveryProjectToRepo(options: {
   });
 
   async function addTeamsToRepository(
-    logger: Logger,
+    logger: LoggerService,
     organization: string,
     repoName: string,
     owner: string,

--- a/app/plugins/scaffolder-backend-module-adp/src/actions/publish/zip.ts
+++ b/app/plugins/scaffolder-backend-module-adp/src/actions/publish/zip.ts
@@ -4,7 +4,7 @@ import {
 } from '@backstage/plugin-scaffolder-node';
 import archiver, { type Archiver } from 'archiver';
 import type { Readable } from 'node:stream';
-import type { Logger } from 'winston';
+import type { LoggerService } from '@backstage/backend-plugin-api';
 
 export type PublishZipActionInput = {
   readonly sourcePath?: string;
@@ -62,7 +62,7 @@ export const publishZipAction = createTemplateAction<
 
 interface CreateArchiveOptions extends archiver.ArchiverOptions {
   readonly format?: archiver.Format;
-  readonly logger?: Logger;
+  readonly logger?: LoggerService;
 }
 
 async function createArchive(
@@ -70,11 +70,11 @@ async function createArchive(
   options: CreateArchiveOptions = {},
 ) {
   const archive = archiver(options.format ?? 'zip', options);
-  using _onWarning = usingListener(archive, 'warning', (err: unknown) =>
-    options.logger?.warn(err),
+  using _onWarning = usingListener(archive, 'warning', (err: Error) =>
+    options.logger?.warn('Create archive warning', err),
   );
-  using _onError = usingListener(archive, 'error', (err: unknown) =>
-    options.logger?.error(err),
+  using _onError = usingListener(archive, 'error', (err: Error) =>
+    options.logger?.error('Create archive error', err),
   );
   const result = getData(archive);
   populate(archive);

--- a/app/plugins/techdocs-backend-module-adp/src/module.test.ts
+++ b/app/plugins/techdocs-backend-module-adp/src/module.test.ts
@@ -15,7 +15,7 @@ describe('adpTechdocsModule', () => {
 
     await startTestBackend({
       extensionPoints: [[techdocsBuildsExtensionPoint, extensionPoint]],
-      features: [adpTechdocsModule()],
+      features: [adpTechdocsModule],
     });
 
     expect(configuredStrategy).toBeDefined();

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -15365,7 +15365,6 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     node-gyp: "npm:^9.0.0"
     pg: "npm:^8.11.3"
-    winston: "npm:^3.2.1"
     zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
Fixes locations where we use deprecated backstage functions & types by replacing them with the updated types.
Also fixes several warnings reported by sonarcloud.

The version bump is a minor bump because I forgot to do that for the main backstage update PR!

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# **How does this PR make you feel**:
![gif]([https://giphy.com/)