### PR TITLE
371568: Implement new method for loading adp entities in to support refresh o…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,9 +5,12 @@
       "name": "Backend",
       "type": "node",
       "request": "launch",
-      "args": "start-backend",
-      "cwd": "${workspaceFolder}/app",
-      "runtimeExecutable": "yarn",
+      "args": [
+        "package",
+        "start"
+      ],
+      "cwd": "${workspaceFolder}/app/packages/backend",
+      "program": "${workspaceFolder}/app/node_modules/.bin/backstage-cli",
       "skipFiles": [
         "<node_internals>/**"
       ],
@@ -25,9 +28,12 @@
       "name": "Frontend",
       "type": "node",
       "request": "launch",
-      "args": "start",
-      "cwd": "${workspaceFolder}/app",
-      "runtimeExecutable": "yarn",
+      "args": [
+        "package",
+        "start"
+      ],
+      "cwd": "${workspaceFolder}/app/packages/app",
+      "program": "${workspaceFolder}/app/node_modules/.bin/backstage-cli",
       "skipFiles": [
         "<node_internals>/**"
       ],
@@ -55,13 +61,14 @@
       "name": "Jest",
       "request": "launch",
       "args": [
+        "repo",
         "test",
         "--runInBand",
         "--watchAll=false",
         "--testTimeout=999999999"
       ],
       "console": "integratedTerminal",
-      "runtimeExecutable": "yarn",
+      "program": "${workspaceFolder}/app/node_modules/.bin/backstage-cli",
       "cwd": "${workspaceFolder}/app",
       "skipFiles": [
         "<node_internals>/**"
@@ -77,13 +84,14 @@
       "name": "Jest: current file",
       "request": "launch",
       "args": [
+        "repo",
         "test",
         "${file}",
         "--runInBand",
         "--watchAll=false",
         "--testTimeout=99999999"
       ],
-      "runtimeExecutable": "yarn",
+      "program": "${workspaceFolder}/app/node_modules/.bin/backstage-cli",
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}/app",
       "skipFiles": [

--- a/app/app-config.production.yaml
+++ b/app/app-config.production.yaml
@@ -1,7 +1,3 @@
-app:
-  # Should be the same as backend.baseUrl when using the `app-backend` plugin.
-  baseUrl: ${APP_BASE_URL}
-
 kubernetes:
   serviceLocatorMethod:
     type: 'multiTenant'
@@ -27,15 +23,6 @@ backend:
   auth:
     keys:
       - secret: ${BACKSTAGE_BACKEND_SECRET}
-  # Note that the baseUrl should be the URL that the browser and other clients
-  # should use when communicating with the backend, i.e. it needs to be
-  # reachable not just from within the backend host, but from all of your
-  # callers. When its value is "http://localhost:7007", it's strictly private
-  # and can't be reached by others.
-  baseUrl: ${APP_BACKEND_BASE_URL}
-  # The listener can also be expressed as a single <host>:<port> string. In this case we bind to
-  # all interfaces, the most permissive setting. The right value depends on your specific deployment.
-  listen: ':7007'
 
   # config options: https://node-postgres.com/api/client
   database:

--- a/app/app-config.yaml
+++ b/app/app-config.yaml
@@ -1,6 +1,6 @@
 app:
   title: ADP Portal
-  baseUrl: http://localhost:3000
+  baseUrl: ${APP_BASE_URL}
   support:
     url: https://github.com/defra/adp-portal/issues
     items:
@@ -17,13 +17,12 @@ permission:
   enabled: true
 
 backend:
-  baseUrl: http://localhost:7007
-  listen:
-    port: 7007
+  baseUrl: ${APP_BACKEND_BASE_URL}
+  listen: ':7007'
   csp:
     connect-src: ["'self'", 'http:', 'https:']
   cors:
-    origin: http://localhost:3000
+    origin: ${APP_BASE_URL}
     methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
     credentials: true
   reading:
@@ -156,6 +155,22 @@ catalog:
         - type: url
           pattern: 'https://github.com/DEFRA/adp-software-templates/**'
 
+    - allow: [Location, Group]
+      locations:
+        - type: url
+          pattern: '${APP_BASE_URL}/onboarding/**'
+
+  # Locations configured to import static data into the catalog
+  locations:
+    - type: url
+      target: https://github.com/DEFRA/adp-software-templates/blob/${ADP_PORTAL_TEMPLATE_VERSION}/catalog-model/all.yaml
+    - type: url
+      target: ${APP_BASE_URL}/onboarding/arms-length-bodies
+    - type: url
+      target: ${APP_BASE_URL}/onboarding/delivery-programmes
+    - type: url
+      target: ${APP_BASE_URL}/onboarding/delivery-projects
+
   processingInterval: { minutes: 60 }
 
   # Providers configured to scan repos in the specified organizations for components to add to the catalog.
@@ -185,12 +200,6 @@ catalog:
           frequency: { hours: 1 }
           timeout: { minutes: 50 }
           initialDelay: { seconds: 15 }
-
-  # 'all users'
-  # Locations configured to import static data into the catalog
-  locations:
-    - type: url
-      target: https://github.com/DEFRA/adp-software-templates/blob/${ADP_PORTAL_TEMPLATE_VERSION}/catalog-model/all.yaml
 
 techRadar:
   data: https://raw.githubusercontent.com/defra/adp-software-templates/${ADP_PORTAL_TEMPLATE_VERSION}/tech-radars/development-tech-radar.json

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.7.9",
+  "version": "1.8.0",
   "private": true,
   "packageManager": "yarn@4.3.1",
   "engines": {

--- a/app/packages/backend/src/index.ts
+++ b/app/packages/backend/src/index.ts
@@ -1,4 +1,8 @@
 import { createBackend } from '@backstage/backend-defaults';
+import {
+  adpOnboardingUrlReaderFactoryRef,
+  createUrlReaderFactory,
+} from '@internal/plugin-adp-backend';
 import fetchApiFactory, {
   fetchApiForPluginMiddleware,
   fetchApiHeadersMiddleware,
@@ -10,7 +14,8 @@ process.on('unhandledRejection', (reason, promise) => {
 
 const backend = createBackend();
 
-// Request middleware
+// Services
+backend.add(createUrlReaderFactory([adpOnboardingUrlReaderFactoryRef]));
 backend.add(
   fetchApiFactory({
     middleware: [

--- a/app/plugins/adp-backend/package.json
+++ b/app/plugins/adp-backend/package.json
@@ -42,6 +42,7 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "knex": "^3.1.0",
+    "yaml": "^2.4.3",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/app/plugins/adp-backend/src/AdpOnboardingUrlReader.ts
+++ b/app/plugins/adp-backend/src/AdpOnboardingUrlReader.ts
@@ -1,0 +1,149 @@
+import type {
+  ReadTreeResponseFactory,
+  ReaderFactory,
+  UrlReaderPredicateTuple,
+} from '@backstage/backend-defaults/urlReader';
+import {
+  type AuthService,
+  type UrlReaderService,
+  type UrlReaderServiceReadTreeOptions,
+  type UrlReaderServiceReadTreeResponse,
+  type UrlReaderServiceReadUrlOptions,
+  type UrlReaderServiceReadUrlResponse,
+  type UrlReaderServiceSearchOptions,
+  type DiscoveryService,
+  createServiceFactory,
+  createServiceRef,
+  coreServices,
+} from '@backstage/backend-plugin-api';
+import type { Config } from '@backstage/config';
+import { NotFoundError, NotModifiedError } from '@backstage/errors';
+import { fetchApiRef, type FetchApi } from '@internal/plugin-fetch-api-backend';
+import { createHash } from 'node:crypto';
+
+export interface AdpOnboardingUrlReaderOptions {
+  readonly config: Config;
+  readonly fetchApi: FetchApi;
+  readonly auth: AuthService;
+  readonly discovery: DiscoveryService;
+  readonly treeResponseFactory: ReadTreeResponseFactory;
+}
+
+export class AdpOnboardingUrlReader implements UrlReaderService {
+  static factory(
+    options: AdpOnboardingUrlReaderOptions,
+  ): UrlReaderPredicateTuple[] {
+    const baseUrl = this.#getBaseUrl(options.config);
+    return [
+      {
+        predicate: url => url.toString().startsWith(baseUrl),
+        reader: new AdpOnboardingUrlReader(options),
+      },
+    ];
+  }
+
+  static #getBaseUrl(config: Config) {
+    return `${config.getString('app.baseUrl')}/onboarding/`;
+  }
+
+  readonly #baseUrl: string;
+  readonly #fetchApi: FetchApi;
+  readonly #discovery: DiscoveryService;
+  readonly #auth: AuthService;
+  readonly #treeResponseFactory: ReadTreeResponseFactory;
+
+  constructor(options: AdpOnboardingUrlReaderOptions) {
+    this.#baseUrl = AdpOnboardingUrlReader.#getBaseUrl(options.config);
+    this.#fetchApi = options.fetchApi;
+    this.#auth = options.auth;
+    this.#treeResponseFactory = options.treeResponseFactory;
+    this.#discovery = options.discovery;
+  }
+
+  async readUrl(
+    url: string,
+    options?: UrlReaderServiceReadUrlOptions,
+  ): Promise<UrlReaderServiceReadUrlResponse> {
+    if (!url.startsWith(this.#baseUrl))
+      throw new Error(`Unsupported url ${url}`);
+
+    const baseUrl = await this.#discovery.getBaseUrl('adp');
+    const { token } = await this.#auth.getPluginRequestToken({
+      onBehalfOf: await this.#auth.getOwnServiceCredentials(),
+      targetPluginId: 'adp',
+    });
+    const fullUrl = `${baseUrl}/catalog/${url.slice(this.#baseUrl.length)}/entity.yaml`;
+    const response = await this.#fetchApi.fetch(fullUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      signal: options?.signal,
+    });
+
+    if (response.status === 304) throw new NotModifiedError();
+    if (response.status === 404) {
+      throw new NotFoundError(
+        `Request failed for ${url}, ${response.status} ${response.statusText}`,
+      );
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Request failed for ${url}, ${response.status} ${response.statusText}`,
+      );
+    }
+    if (response.headers.get('content-type') !== 'application/yaml') {
+      throw new Error(
+        `Request failed for ${url}, expected yaml, got Content-Type: ${response.headers.get('content-type')}`,
+      );
+    }
+
+    const content = await response.text();
+    const etag = createHash('md5').update(content).digest('hex');
+    if (etag === options?.etag) throw new NotModifiedError();
+
+    return {
+      buffer: () => Promise.resolve(Buffer.from(content)),
+      etag,
+    };
+  }
+
+  async readTree(
+    _url: string,
+    _options?: UrlReaderServiceReadTreeOptions,
+  ): Promise<UrlReaderServiceReadTreeResponse> {
+    return this.#treeResponseFactory.fromReadableArray([]);
+  }
+
+  async search(_url: string, _options?: UrlReaderServiceSearchOptions) {
+    return {
+      etag: '0',
+      files: [],
+    };
+  }
+}
+
+export const adpOnboardingUrlReaderFactoryRef = createServiceRef<ReaderFactory>(
+  {
+    id: 'adp.onboarding-url-reader.factory',
+    scope: 'plugin',
+    defaultFactory(service) {
+      return Promise.resolve(
+        createServiceFactory({
+          service,
+          deps: {
+            fetchApi: fetchApiRef,
+            auth: coreServices.auth,
+            discovery: coreServices.discovery,
+          },
+          factory(deps) {
+            return options =>
+              AdpOnboardingUrlReader.factory({
+                ...deps,
+                ...options,
+              });
+          },
+        }),
+      );
+    },
+  },
+);

--- a/app/plugins/adp-backend/src/armsLengthBody/armsLengthBodyStore.ts
+++ b/app/plugins/adp-backend/src/armsLengthBody/armsLengthBodyStore.ts
@@ -52,9 +52,18 @@ export class ArmsLengthBodyStore {
     return this.#client<arms_length_body>(arms_length_body_name);
   }
 
-  async getAll(): Promise<ArmsLengthBody[]> {
+  async getAll(columns?: undefined): Promise<ArmsLengthBody[]>;
+  async getAll<Column extends keyof arms_length_body>(
+    columns: readonly Column[],
+  ): Promise<Pick<ArmsLengthBody, Column>[]>;
+  async getAll(
+    columns: readonly (keyof arms_length_body)[],
+  ): Promise<Partial<ArmsLengthBody>[]>;
+  async getAll(
+    columns?: readonly (keyof arms_length_body)[],
+  ): Promise<Partial<ArmsLengthBody>[]> {
     const result = await this.#table
-      .select(...allColumns)
+      .select(...(columns ?? allColumns))
       .orderBy('created_at');
 
     return result.map(row => this.#normalize(row));
@@ -64,6 +73,16 @@ export class ArmsLengthBodyStore {
     if (!isUUID(id)) throw notFound();
     const row = await this.#table
       .where('id', id)
+      .select(...allColumns)
+      .first();
+
+    if (row === undefined) throw notFound();
+
+    return this.#normalize(row);
+  }
+  async getByName(name: string): Promise<ArmsLengthBody> {
+    const row = await this.#table
+      .where('name', name)
       .select(...allColumns)
       .first();
 

--- a/app/plugins/adp-backend/src/createUrlReaderFactory.ts
+++ b/app/plugins/adp-backend/src/createUrlReaderFactory.ts
@@ -1,0 +1,38 @@
+import {
+  UrlReaders,
+  type ReaderFactory,
+} from '@backstage/backend-defaults/urlReader';
+import {
+  type ServiceRef,
+  coreServices,
+  createServiceFactory,
+  type UrlReaderService,
+} from '@backstage/backend-plugin-api';
+
+export function createUrlReaderFactory(
+  factories: readonly ServiceRef<ReaderFactory>[],
+) {
+  return createServiceFactory<
+    UrlReaderService,
+    UrlReaderService,
+    {
+      logger: typeof coreServices.logger;
+      config: typeof coreServices.rootConfig;
+      [key: number]: ServiceRef<ReaderFactory>;
+    }
+  >({
+    service: coreServices.urlReader,
+    deps: {
+      logger: coreServices.logger,
+      config: coreServices.rootConfig,
+      ...factories,
+    },
+    factory({ logger, config, ...factoryImpls }) {
+      return UrlReaders.default({
+        config,
+        logger,
+        factories: factories.map((_, i) => factoryImpls[i]),
+      });
+    },
+  });
+}

--- a/app/plugins/adp-backend/src/deliveryProgramme/deliveryProgrammeStore.ts
+++ b/app/plugins/adp-backend/src/deliveryProgramme/deliveryProgrammeStore.ts
@@ -56,9 +56,18 @@ export class DeliveryProgrammeStore {
     return this.#client<delivery_programme>(delivery_programme_name);
   }
 
-  async getAll(): Promise<DeliveryProgramme[]> {
+  async getAll(columns?: undefined): Promise<DeliveryProgramme[]>;
+  async getAll<Column extends keyof delivery_programme>(
+    columns: readonly Column[],
+  ): Promise<Pick<DeliveryProgramme, Column>[]>;
+  async getAll(
+    columns: readonly (keyof delivery_programme)[],
+  ): Promise<Partial<DeliveryProgramme>[]>;
+  async getAll(
+    columns?: readonly (keyof delivery_programme)[],
+  ): Promise<Partial<DeliveryProgramme>[]> {
     const result = await this.#table
-      .select(...allColumns)
+      .select(...(columns ?? allColumns))
       .orderBy('created_at');
 
     return result.map(r => this.#normalize(r));
@@ -68,6 +77,17 @@ export class DeliveryProgrammeStore {
     if (!isUUID(id)) throw notFound();
     const result = await this.#table
       .where('id', id)
+      .select(...allColumns)
+      .first();
+
+    if (result === undefined) throw notFound();
+
+    return this.#normalize(result);
+  }
+
+  async getByName(name: string): Promise<DeliveryProgramme> {
+    const result = await this.#table
+      .where('name', name)
       .select(...allColumns)
       .first();
 

--- a/app/plugins/adp-backend/src/index.ts
+++ b/app/plugins/adp-backend/src/index.ts
@@ -1,4 +1,3 @@
-export * from './routes/deliveryProjectUsers';
 export * from './deliveryProgramme';
 export * from './deliveryProject';
 export * from './armsLengthBody';
@@ -9,4 +8,6 @@ export * from './database';
 export * from './deliveryProjectUser';
 export * from './entraId';
 export * from './permissions';
+export * from './createUrlReaderFactory';
+export * from './AdpOnboardingUrlReader';
 export { adpPlugin as default } from './plugin';

--- a/app/plugins/adp-backend/src/plugin.test.ts
+++ b/app/plugins/adp-backend/src/plugin.test.ts
@@ -14,6 +14,9 @@ describe('adpPlugin', () => {
         mockServices.database.factory(),
         mockServices.rootConfig.factory({
           data: {
+            app: {
+              baseUrl: 'https://test.com',
+            },
             backend: {
               baseUrl: 'https://test.com',
             },

--- a/app/plugins/adp-backend/src/routes/armsLengthBodies/create.ts
+++ b/app/plugins/adp-backend/src/routes/armsLengthBodies/create.ts
@@ -6,15 +6,17 @@ import { z } from 'zod';
 import { authIdentityRef } from '../../refs';
 import { coreServices } from '@backstage/backend-plugin-api';
 import errorMapping from './errorMapping';
+import { fireAndForgetCatalogRefresherRef } from '../../services';
 
 export default createEndpointRef({
   deps: {
     armsLengthBodyStore: armsLengthBodyStoreRef,
     identity: authIdentityRef,
     config: coreServices.rootConfig,
+    catalogRefresher: fireAndForgetCatalogRefresherRef,
   },
   factory({
-    deps: { armsLengthBodyStore, identity, config },
+    deps: { armsLengthBodyStore, identity, config, catalogRefresher },
     responses: { created, validationErrors },
   }) {
     const owner = getOwner(config);
@@ -34,6 +36,7 @@ export default createEndpointRef({
       if (!result.success)
         return validationErrors(result.errors, errorMapping, body);
 
+      await catalogRefresher.refresh('location:default/arms-length-bodies');
       return created().json(result.value);
     };
   },

--- a/app/plugins/adp-backend/src/routes/armsLengthBodies/edit.ts
+++ b/app/plugins/adp-backend/src/routes/armsLengthBodies/edit.ts
@@ -5,14 +5,16 @@ import type { UpdateArmsLengthBodyRequest } from '@internal/plugin-adp-common';
 import { z } from 'zod';
 import { authIdentityRef } from '../../refs';
 import errorMapping from './errorMapping';
+import { fireAndForgetCatalogRefresherRef } from '../../services';
 
 export default createEndpointRef({
   deps: {
     armsLengthBodyStore: armsLengthBodyStoreRef,
     identity: authIdentityRef,
+    catalogRefresher: fireAndForgetCatalogRefresherRef,
   },
   factory({
-    deps: { armsLengthBodyStore, identity },
+    deps: { armsLengthBodyStore, identity, catalogRefresher },
     responses: { ok, validationErrors },
   }) {
     const parseBody = createParser<UpdateArmsLengthBodyRequest>(
@@ -32,6 +34,7 @@ export default createEndpointRef({
       if (!result.success)
         return validationErrors(result.errors, errorMapping, body);
 
+      await catalogRefresher.refresh(`group:default/${result.value.name}`);
       return ok().json(result.value);
     };
   },

--- a/app/plugins/adp-backend/src/routes/armsLengthBodies/get.test.ts
+++ b/app/plugins/adp-backend/src/routes/armsLengthBodies/get.test.ts
@@ -15,6 +15,7 @@ describe('default', () => {
       get: jest.fn(),
       getAll: jest.fn(),
       update: jest.fn(),
+      getByName: jest.fn(),
     };
 
     const handler = await testHelpers.getAutoServiceRef(get, [

--- a/app/plugins/adp-backend/src/routes/armsLengthBodies/getAll.test.ts
+++ b/app/plugins/adp-backend/src/routes/armsLengthBodies/getAll.test.ts
@@ -22,12 +22,14 @@ describe('default', () => {
       get: jest.fn(),
       getAll: jest.fn(),
       update: jest.fn(),
+      getByName: jest.fn(),
     };
     const programmes: jest.Mocked<IDeliveryProgrammeStore> = {
       add: jest.fn(),
       get: jest.fn(),
       getAll: jest.fn(),
       update: jest.fn(),
+      getByName: jest.fn(),
     };
 
     const handler = await testHelpers.getAutoServiceRef(getAll, [

--- a/app/plugins/adp-backend/src/routes/armsLengthBodies/getNames.test.ts
+++ b/app/plugins/adp-backend/src/routes/armsLengthBodies/getNames.test.ts
@@ -15,6 +15,7 @@ describe('default', () => {
       get: jest.fn(),
       getAll: jest.fn(),
       update: jest.fn(),
+      getByName: jest.fn(),
     };
 
     const handler = await testHelpers.getAutoServiceRef(getNames, [

--- a/app/plugins/adp-backend/src/routes/armsLengthBodies/index.test.ts
+++ b/app/plugins/adp-backend/src/routes/armsLengthBodies/index.test.ts
@@ -64,8 +64,7 @@ describe('default', () => {
 
   describe('GET /', () => {
     it('Should call getAll', async () => {
-      const { app, mockGetAll, mockCheckAuth } = await setup();
-      mockCheckAuth.mockReturnValue((_req, _res, next) => next());
+      const { app, mockGetAll } = await setup();
       mockGetAll.mockImplementationOnce((_, res) =>
         res.status(200).json({ result: 'Success!' }),
       );
@@ -81,8 +80,7 @@ describe('default', () => {
   });
   describe('GET /health', () => {
     it('Should call health', async () => {
-      const { app, mockHealth, mockCheckAuth } = await setup();
-      mockCheckAuth.mockReturnValue((_req, _res, next) => next());
+      const { app, mockHealth } = await setup();
       mockHealth.mockImplementationOnce((_, res) =>
         res.status(200).json({ result: 'Success!' }),
       );
@@ -98,8 +96,7 @@ describe('default', () => {
   });
   describe('GET /names', () => {
     it('Should call getNames', async () => {
-      const { app, mockGetNames, mockCheckAuth } = await setup();
-      mockCheckAuth.mockReturnValue((_req, _res, next) => next());
+      const { app, mockGetNames } = await setup();
       mockGetNames.mockImplementationOnce((_, res) =>
         res.status(200).json({ result: 'Success!' }),
       );
@@ -115,8 +112,7 @@ describe('default', () => {
   });
   describe('GET /:id', () => {
     it('Should call get', async () => {
-      const { app, mockGet, mockCheckAuth } = await setup();
-      mockCheckAuth.mockReturnValue((_req, _res, next) => next());
+      const { app, mockGet } = await setup();
       mockGet.mockImplementationOnce((req, res) =>
         res.status(200).json({ result: 'Success!', id: req.params.id }),
       );

--- a/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/get.yaml.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/get.yaml.test.ts
@@ -1,0 +1,73 @@
+import {
+  type IArmsLengthBodyStore,
+  armsLengthBodyStoreRef,
+} from '../../../armsLengthBody';
+import getYaml from './get.yaml';
+import { testHelpers } from '../../../utils/testHelpers';
+import request from 'supertest';
+import { randomUUID } from 'node:crypto';
+
+describe('default', () => {
+  async function setup() {
+    const albs: jest.Mocked<IArmsLengthBodyStore> = {
+      add: jest.fn(),
+      get: jest.fn(),
+      getAll: jest.fn(),
+      update: jest.fn(),
+      getByName: jest.fn(),
+    };
+
+    const handler = await testHelpers.getAutoServiceRef(getYaml, [
+      testHelpers.provideService(armsLengthBodyStoreRef, albs),
+    ]);
+
+    const app = testHelpers.makeApp(x => x.get('/:name/entity.yaml', handler));
+
+    return { handler, app, albs };
+  }
+
+  it('Should return ok with the data from the store', async () => {
+    const { app, albs } = await setup();
+    const albId = randomUUID();
+    albs.getByName.mockResolvedValueOnce({
+      name: 'test-alb',
+      created_at: new Date(),
+      creator: randomUUID(),
+      description: 'My test arms length body',
+      id: albId,
+      owner: randomUUID(),
+      title: 'Test ALB',
+      updated_at: new Date(),
+      alias: 'XYZ',
+      url: 'https://test.com',
+    });
+
+    const {
+      status,
+      text,
+      header: { 'content-type': contentType },
+    } = await request(app).get(`/test-alb/entity.yaml`);
+
+    expect(albs.getByName).toHaveBeenCalledTimes(1);
+    expect(albs.getByName).toHaveBeenCalledWith('test-alb');
+    expect({ status, text, contentType }).toMatchObject({
+      status: 200,
+      contentType: 'application/yaml',
+      text: `apiVersion: backstage.io/v1beta1
+kind: Group
+metadata:
+  name: test-alb
+  title: Test ALB (XYZ)
+  description: My test arms length body
+  tags: []
+  links:
+    - url: https://test.com
+  annotations:
+    adp.defra.gov.uk/arms-length-body-id: ${albId}
+spec:
+  type: arms-length-body
+  children: []
+`,
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/get.yaml.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/get.yaml.ts
@@ -1,0 +1,38 @@
+import type { GroupEntity } from '@backstage/catalog-model';
+import type { Request } from 'express';
+import { createEndpointRef } from '../../util';
+import {
+  ARMS_LENGTH_BODY_ID_ANNOTATION,
+  createTransformerTitle,
+} from '../util';
+import { armsLengthBodyStoreRef } from '../../../armsLengthBody';
+
+export default createEndpointRef({
+  deps: {
+    armsLengthBodyStore: armsLengthBodyStoreRef,
+  },
+  factory({ deps: { armsLengthBodyStore }, responses: { ok } }) {
+    return async (request: Request<{ name: string }>) => {
+      const entity = await armsLengthBodyStore.getByName(request.params.name);
+
+      return ok().yaml({
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Group',
+        metadata: {
+          name: entity.name,
+          title: createTransformerTitle(entity.title, entity.alias),
+          description: entity.description,
+          tags: [],
+          links: [...(entity.url ? [{ url: entity.url }] : [])],
+          annotations: {
+            [ARMS_LENGTH_BODY_ID_ANNOTATION]: entity.id,
+          },
+        },
+        spec: {
+          type: 'arms-length-body',
+          children: [],
+        },
+      } satisfies GroupEntity);
+    };
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/getAll.yaml.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/getAll.yaml.test.ts
@@ -1,0 +1,74 @@
+import getAllYaml from './getAll.yaml';
+import { testHelpers } from '../../../utils/testHelpers';
+import request from 'supertest';
+import { coreServices } from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
+import {
+  armsLengthBodyStoreRef,
+  type IArmsLengthBodyStore,
+} from '../../../armsLengthBody';
+
+describe('default', () => {
+  async function setup() {
+    const config = mockServices.rootConfig({
+      data: {
+        app: {
+          baseUrl: 'http://defra-adp:3000',
+        },
+      },
+    });
+
+    const albs: jest.Mocked<IArmsLengthBodyStore> = {
+      add: jest.fn(),
+      get: jest.fn(),
+      getAll: jest.fn(),
+      update: jest.fn(),
+      getByName: jest.fn(),
+    };
+
+    const handler = await testHelpers.getAutoServiceRef(getAllYaml, [
+      testHelpers.provideService(armsLengthBodyStoreRef, albs),
+      testHelpers.provideService(coreServices.rootConfig, config),
+    ]);
+
+    const app = testHelpers.makeApp(x => x.get('/index.yaml', handler));
+
+    return { handler, app, albs };
+  }
+
+  it('Should return ok with the data from the store', async () => {
+    const { app, albs } = await setup();
+    albs.getAll.mockResolvedValueOnce([
+      { name: 'alb-1' },
+      { name: 'alb-2' },
+      { name: 'alb-3' },
+      { name: 'alb-4' },
+    ]);
+
+    const {
+      status,
+      text,
+      header: { 'content-type': contentType },
+    } = await request(app).get(`/index.yaml`);
+
+    expect(albs.getAll).toHaveBeenCalledTimes(1);
+    expect(albs.getAll).toHaveBeenCalledWith(['name']);
+    expect({ status, text, contentType }).toMatchObject({
+      status: 200,
+      contentType: 'application/yaml',
+      text: `apiVersion: backstage.io/v1beta1
+kind: Location
+metadata:
+  name: arms-length-bodies
+  description: All the arms length bodies available in the system
+spec:
+  type: url
+  targets:
+    - http://defra-adp:3000/onboarding/arms-length-bodies/alb-1
+    - http://defra-adp:3000/onboarding/arms-length-bodies/alb-2
+    - http://defra-adp:3000/onboarding/arms-length-bodies/alb-3
+    - http://defra-adp:3000/onboarding/arms-length-bodies/alb-4
+`,
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/getAll.yaml.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/getAll.yaml.ts
@@ -1,0 +1,30 @@
+import type { LocationEntity } from '@backstage/catalog-model';
+import { createEndpointRef } from '../../util';
+import { coreServices } from '@backstage/backend-plugin-api';
+import { armsLengthBodyStoreRef } from '../../../armsLengthBody';
+
+export default createEndpointRef({
+  deps: {
+    armsLengthBodyStore: armsLengthBodyStoreRef,
+    config: coreServices.rootConfig,
+  },
+  factory({ deps: { armsLengthBodyStore, config }, responses: { ok } }) {
+    const baseUrl = `${config.getString('app.baseUrl')}/onboarding`;
+    return async () => {
+      const entities = await armsLengthBodyStore.getAll(['name']);
+
+      return ok().yaml({
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Location',
+        metadata: {
+          name: 'arms-length-bodies',
+          description: 'All the arms length bodies available in the system',
+        },
+        spec: {
+          type: 'url',
+          targets: entities.map(p => `${baseUrl}/arms-length-bodies/${p.name}`),
+        },
+      } satisfies LocationEntity);
+    };
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/health.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/health.test.ts
@@ -1,0 +1,40 @@
+import health from './health';
+import { testHelpers } from '../../../utils/testHelpers';
+import request from 'supertest';
+import {
+  type LoggerService,
+  coreServices,
+} from '@backstage/backend-plugin-api';
+
+describe('default', () => {
+  async function setup() {
+    const logger: jest.Mocked<LoggerService> = {
+      child: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    };
+
+    const handler = await testHelpers.getAutoServiceRef(health, [
+      testHelpers.provideService(coreServices.logger, logger),
+    ]);
+
+    const app = testHelpers.makeApp(x => x.get('/', handler));
+
+    return { handler, app, logger };
+  }
+
+  it('Log pong and return 200 ok', async () => {
+    const { app, logger } = await setup();
+
+    const { status, body } = await request(app).get(`/`);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('PONG!');
+    expect({ status, body }).toMatchObject({
+      status: 200,
+      body: { status: 'ok' },
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/health.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/health.ts
@@ -1,0 +1,14 @@
+import { coreServices } from '@backstage/backend-plugin-api';
+import { createEndpointRef } from '../../util';
+
+export default createEndpointRef({
+  deps: {
+    logger: coreServices.logger,
+  },
+  factory({ deps: { logger }, responses: { ok } }) {
+    return () => {
+      logger.info('PONG!');
+      return ok().json({ status: 'ok' });
+    };
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/index.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/index.test.ts
@@ -1,0 +1,89 @@
+import express from 'express';
+import { testHelpers } from '../../../utils/testHelpers';
+import index from './index';
+import health from './health';
+import request from 'supertest';
+import getAllYaml from './getAll.yaml';
+import getYaml from './get.yaml';
+
+describe('default', () => {
+  async function setup() {
+    function mockHandler<T extends (...args: never) => unknown>() {
+      return jest.fn(() => {
+        throw new Error('Unexpected call');
+      }) as unknown as jest.MockedFn<T>;
+    }
+
+    const mockGetAllYaml = mockHandler<(typeof getAllYaml)['T']>();
+    const mockGetYaml = mockHandler<(typeof getYaml)['T']>();
+    const mockHealth = mockHandler<(typeof health)['T']>();
+
+    const handler = await testHelpers.getAutoServiceRef(index, [
+      testHelpers.provideService(getAllYaml, mockGetAllYaml),
+      testHelpers.provideService(getYaml, mockGetYaml),
+      testHelpers.provideService(health, mockHealth),
+    ]);
+
+    const app = express();
+    app.use(handler);
+
+    return {
+      handler,
+      app,
+      mockGetAllYaml,
+      mockGetYaml,
+      mockHealth,
+    };
+  }
+
+  describe('GET /entity.yaml', () => {
+    it('Should call getAllYaml', async () => {
+      const { app, mockGetAllYaml } = await setup();
+      mockGetAllYaml.mockImplementationOnce((_, res) =>
+        res.status(200).json({ result: 'Success!' }),
+      );
+
+      const { status, body } = await request(app).get('/entity.yaml');
+
+      expect(mockGetAllYaml).toHaveBeenCalledTimes(1);
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!' },
+      });
+    });
+  });
+  describe('GET /:name/entity.yaml', () => {
+    it('Should call getYaml', async () => {
+      const { app, mockGetYaml } = await setup();
+      mockGetYaml.mockImplementationOnce((req, res) =>
+        res.status(200).json({ result: 'Success!', name: req.params.name }),
+      );
+
+      const { status, body } = await request(app).get(
+        '/core-defra/entity.yaml',
+      );
+
+      expect(mockGetYaml).toHaveBeenCalledTimes(1);
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!', name: 'core-defra' },
+      });
+    });
+  });
+  describe('GET /health', () => {
+    it('Should call health', async () => {
+      const { app, mockHealth } = await setup();
+      mockHealth.mockImplementationOnce((_, res) =>
+        res.status(200).json({ result: 'Success!' }),
+      );
+
+      const { status, body } = await request(app).get('/health');
+
+      expect(mockHealth).toHaveBeenCalledTimes(1);
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!' },
+      });
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/index.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/arms-length-bodies/index.ts
@@ -1,0 +1,20 @@
+import { createRouterRef } from '../../util';
+import getAllYaml from './getAll.yaml';
+import getYaml from './get.yaml';
+import health from './health';
+import { middlewareFactoryRef } from '../../../refs';
+
+export default createRouterRef({
+  deps: {
+    middleware: middlewareFactoryRef,
+    getAllYaml,
+    getYaml,
+    health,
+  },
+  factory({ router, deps }) {
+    router.get('/entity.yaml', deps.getAllYaml);
+    router.get('/:name/entity.yaml', deps.getYaml);
+    router.get('/health', deps.health);
+    router.use(deps.middleware.error());
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/get.yaml.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/get.yaml.test.ts
@@ -1,0 +1,132 @@
+import {
+  type IDeliveryProgrammeStore,
+  deliveryProgrammeStoreRef,
+} from '../../../deliveryProgramme';
+import {
+  type IArmsLengthBodyStore,
+  armsLengthBodyStoreRef,
+} from '../../../armsLengthBody';
+import {
+  type IDeliveryProgrammeAdminStore,
+  deliveryProgrammeAdminStoreRef,
+} from '../../../deliveryProgrammeAdmin';
+import getYaml from './get.yaml';
+import { testHelpers } from '../../../utils/testHelpers';
+import request from 'supertest';
+import { randomUUID } from 'node:crypto';
+
+describe('default', () => {
+  async function setup() {
+    const albs: jest.Mocked<IArmsLengthBodyStore> = {
+      add: jest.fn(),
+      get: jest.fn(),
+      getAll: jest.fn(),
+      update: jest.fn(),
+      getByName: jest.fn(),
+    };
+    const programmes: jest.Mocked<IDeliveryProgrammeStore> = {
+      add: jest.fn(),
+      get: jest.fn(),
+      getAll: jest.fn(),
+      update: jest.fn(),
+      getByName: jest.fn(),
+    };
+    const programmeAdmins: jest.Mocked<IDeliveryProgrammeAdminStore> = {
+      add: jest.fn(),
+      getAll: jest.fn(),
+      delete: jest.fn(),
+      getByAADEntityRef: jest.fn(),
+      getByDeliveryProgramme: jest.fn(),
+    };
+
+    const handler = await testHelpers.getAutoServiceRef(getYaml, [
+      testHelpers.provideService(armsLengthBodyStoreRef, albs),
+      testHelpers.provideService(deliveryProgrammeStoreRef, programmes),
+      testHelpers.provideService(
+        deliveryProgrammeAdminStoreRef,
+        programmeAdmins,
+      ),
+    ]);
+
+    const app = testHelpers.makeApp(x => x.get('/:name/entity.yaml', handler));
+
+    return { handler, app, albs, programmes, programmeAdmins };
+  }
+
+  it('Should return ok with the data from the store', async () => {
+    const { app, albs, programmes, programmeAdmins } = await setup();
+    const albId = randomUUID();
+    const programmeId = randomUUID();
+    programmes.getByName.mockResolvedValueOnce({
+      arms_length_body_id: albId,
+      id: programmeId,
+      created_at: new Date(),
+      delivery_programme_admins: [],
+      delivery_programme_code: 'ABC',
+      description: 'My test delivery programme',
+      name: 'test-programme',
+      title: 'Test Programme',
+      updated_at: new Date(),
+      alias: 'XYZ',
+      url: 'https://test.com',
+    });
+    albs.get.mockResolvedValueOnce({
+      name: 'test-alb',
+      created_at: new Date(),
+      creator: randomUUID(),
+      description: randomUUID(),
+      id: randomUUID(),
+      owner: randomUUID(),
+      title: randomUUID(),
+      updated_at: new Date(),
+    });
+    programmeAdmins.getByDeliveryProgramme.mockResolvedValueOnce(
+      ['admin.1@email.com', 'admin.2@email.com'].map(email => ({
+        aad_entity_ref_id: randomUUID(),
+        delivery_programme_id: randomUUID(),
+        email,
+        id: randomUUID(),
+        name: randomUUID(),
+        updated_at: new Date(),
+      })),
+    );
+
+    const {
+      status,
+      text,
+      header: { 'content-type': contentType },
+    } = await request(app).get(`/test-programme/entity.yaml`);
+
+    expect(programmes.getByName).toHaveBeenCalledTimes(1);
+    expect(programmes.getByName).toHaveBeenCalledWith('test-programme');
+    expect(albs.get).toHaveBeenCalledTimes(1);
+    expect(albs.get).toHaveBeenCalledWith(albId);
+    expect(programmeAdmins.getByDeliveryProgramme).toHaveBeenCalledTimes(1);
+    expect(programmeAdmins.getByDeliveryProgramme).toHaveBeenCalledWith(
+      programmeId,
+    );
+    expect({ status, text, contentType }).toMatchObject({
+      status: 200,
+      contentType: 'application/yaml',
+      text: `apiVersion: backstage.io/v1beta1
+kind: Group
+metadata:
+  name: test-programme
+  title: Test Programme (XYZ)
+  description: My test delivery programme
+  tags: []
+  links:
+    - url: https://test.com
+  annotations:
+    adp.defra.gov.uk/delivery-programme-id: ${programmeId}
+spec:
+  type: delivery-programme
+  parent: group:default/test-alb
+  members:
+    - admin.1_email.com
+    - admin.2_email.com
+  children: []
+`,
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/get.yaml.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/get.yaml.ts
@@ -1,0 +1,58 @@
+import type { GroupEntity } from '@backstage/catalog-model';
+import type { Request } from 'express';
+import { deliveryProgrammeStoreRef } from '../../../deliveryProgramme';
+import { createEndpointRef } from '../../util';
+import {
+  DELIVERY_PROGRAMME_ID_ANNOTATION,
+  createTransformerTitle,
+} from '../util';
+import { deliveryProgrammeAdminStoreRef } from '../../../deliveryProgrammeAdmin';
+import { normalizeUsername } from '@internal/plugin-adp-common';
+import { armsLengthBodyStoreRef } from '../../../armsLengthBody';
+
+export default createEndpointRef({
+  deps: {
+    armsLengthBodyStore: armsLengthBodyStoreRef,
+    deliveryProgrammeStore: deliveryProgrammeStoreRef,
+    deliveryProgrammeAdminStore: deliveryProgrammeAdminStoreRef,
+  },
+  factory({
+    deps: {
+      deliveryProgrammeStore,
+      deliveryProgrammeAdminStore,
+      armsLengthBodyStore,
+    },
+    responses: { ok },
+  }) {
+    return async (request: Request<{ name: string }>) => {
+      const entity = await deliveryProgrammeStore.getByName(
+        request.params.name,
+      );
+      const parent = await armsLengthBodyStore.get(entity.arms_length_body_id);
+      const children = await deliveryProgrammeAdminStore.getByDeliveryProgramme(
+        entity.id,
+      );
+
+      return ok().yaml({
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Group',
+        metadata: {
+          name: entity.name,
+          title: createTransformerTitle(entity.title, entity.alias),
+          description: entity.description,
+          tags: [],
+          links: [...(entity.url ? [{ url: entity.url }] : [])],
+          annotations: {
+            [DELIVERY_PROGRAMME_ID_ANNOTATION]: entity.id,
+          },
+        },
+        spec: {
+          type: 'delivery-programme',
+          parent: `group:default/${parent.name}`,
+          members: children.map(m => normalizeUsername(m.email)),
+          children: [],
+        },
+      } satisfies GroupEntity);
+    };
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/getAll.yaml.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/getAll.yaml.test.ts
@@ -1,0 +1,74 @@
+import {
+  type IDeliveryProgrammeStore,
+  deliveryProgrammeStoreRef,
+} from '../../../deliveryProgramme';
+import getAllYaml from './getAll.yaml';
+import { testHelpers } from '../../../utils/testHelpers';
+import request from 'supertest';
+import { coreServices } from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
+
+describe('default', () => {
+  async function setup() {
+    const config = mockServices.rootConfig({
+      data: {
+        app: {
+          baseUrl: 'http://defra-adp:3000',
+        },
+      },
+    });
+
+    const programmes: jest.Mocked<IDeliveryProgrammeStore> = {
+      add: jest.fn(),
+      get: jest.fn(),
+      getAll: jest.fn(),
+      update: jest.fn(),
+      getByName: jest.fn(),
+    };
+
+    const handler = await testHelpers.getAutoServiceRef(getAllYaml, [
+      testHelpers.provideService(deliveryProgrammeStoreRef, programmes),
+      testHelpers.provideService(coreServices.rootConfig, config),
+    ]);
+
+    const app = testHelpers.makeApp(x => x.get('/index.yaml', handler));
+
+    return { handler, app, programmes };
+  }
+
+  it('Should return ok with the data from the store', async () => {
+    const { app, programmes } = await setup();
+    programmes.getAll.mockResolvedValueOnce([
+      { name: 'programme-1' },
+      { name: 'programme-2' },
+      { name: 'programme-3' },
+      { name: 'programme-4' },
+    ]);
+
+    const {
+      status,
+      text,
+      header: { 'content-type': contentType },
+    } = await request(app).get(`/index.yaml`);
+
+    expect(programmes.getAll).toHaveBeenCalledTimes(1);
+    expect(programmes.getAll).toHaveBeenCalledWith(['name']);
+    expect({ status, text, contentType }).toMatchObject({
+      status: 200,
+      contentType: 'application/yaml',
+      text: `apiVersion: backstage.io/v1beta1
+kind: Location
+metadata:
+  name: delivery-programmes
+  description: All the delivery programmes available in the system
+spec:
+  type: url
+  targets:
+    - http://defra-adp:3000/onboarding/delivery-programmes/programme-1
+    - http://defra-adp:3000/onboarding/delivery-programmes/programme-2
+    - http://defra-adp:3000/onboarding/delivery-programmes/programme-3
+    - http://defra-adp:3000/onboarding/delivery-programmes/programme-4
+`,
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/getAll.yaml.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/getAll.yaml.ts
@@ -1,0 +1,32 @@
+import type { LocationEntity } from '@backstage/catalog-model';
+import { deliveryProgrammeStoreRef } from '../../../deliveryProgramme';
+import { createEndpointRef } from '../../util';
+import { coreServices } from '@backstage/backend-plugin-api';
+
+export default createEndpointRef({
+  deps: {
+    deliveryProgrammeStore: deliveryProgrammeStoreRef,
+    config: coreServices.rootConfig,
+  },
+  factory({ deps: { deliveryProgrammeStore, config }, responses: { ok } }) {
+    const baseUrl = `${config.getString('app.baseUrl')}/onboarding`;
+    return async () => {
+      const entities = await deliveryProgrammeStore.getAll(['name']);
+
+      return ok().yaml({
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Location',
+        metadata: {
+          name: 'delivery-programmes',
+          description: 'All the delivery programmes available in the system',
+        },
+        spec: {
+          type: 'url',
+          targets: entities.map(
+            p => `${baseUrl}/delivery-programmes/${p.name}`,
+          ),
+        },
+      } satisfies LocationEntity);
+    };
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/health.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/health.test.ts
@@ -1,0 +1,40 @@
+import health from './health';
+import { testHelpers } from '../../../utils/testHelpers';
+import request from 'supertest';
+import {
+  type LoggerService,
+  coreServices,
+} from '@backstage/backend-plugin-api';
+
+describe('default', () => {
+  async function setup() {
+    const logger: jest.Mocked<LoggerService> = {
+      child: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    };
+
+    const handler = await testHelpers.getAutoServiceRef(health, [
+      testHelpers.provideService(coreServices.logger, logger),
+    ]);
+
+    const app = testHelpers.makeApp(x => x.get('/', handler));
+
+    return { handler, app, logger };
+  }
+
+  it('Log pong and return 200 ok', async () => {
+    const { app, logger } = await setup();
+
+    const { status, body } = await request(app).get(`/`);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('PONG!');
+    expect({ status, body }).toMatchObject({
+      status: 200,
+      body: { status: 'ok' },
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/health.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/health.ts
@@ -1,0 +1,14 @@
+import { coreServices } from '@backstage/backend-plugin-api';
+import { createEndpointRef } from '../../util';
+
+export default createEndpointRef({
+  deps: {
+    logger: coreServices.logger,
+  },
+  factory({ deps: { logger }, responses: { ok } }) {
+    return () => {
+      logger.info('PONG!');
+      return ok().json({ status: 'ok' });
+    };
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/index.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/index.test.ts
@@ -1,0 +1,89 @@
+import express from 'express';
+import { testHelpers } from '../../../utils/testHelpers';
+import index from './index';
+import health from './health';
+import request from 'supertest';
+import getAllYaml from './getAll.yaml';
+import getYaml from './get.yaml';
+
+describe('default', () => {
+  async function setup() {
+    function mockHandler<T extends (...args: never) => unknown>() {
+      return jest.fn(() => {
+        throw new Error('Unexpected call');
+      }) as unknown as jest.MockedFn<T>;
+    }
+
+    const mockGetAllYaml = mockHandler<(typeof getAllYaml)['T']>();
+    const mockGetYaml = mockHandler<(typeof getYaml)['T']>();
+    const mockHealth = mockHandler<(typeof health)['T']>();
+
+    const handler = await testHelpers.getAutoServiceRef(index, [
+      testHelpers.provideService(getAllYaml, mockGetAllYaml),
+      testHelpers.provideService(getYaml, mockGetYaml),
+      testHelpers.provideService(health, mockHealth),
+    ]);
+
+    const app = express();
+    app.use(handler);
+
+    return {
+      handler,
+      app,
+      mockGetAllYaml,
+      mockGetYaml,
+      mockHealth,
+    };
+  }
+
+  describe('GET /entity.yaml', () => {
+    it('Should call getAllYaml', async () => {
+      const { app, mockGetAllYaml } = await setup();
+      mockGetAllYaml.mockImplementationOnce((_, res) =>
+        res.status(200).json({ result: 'Success!' }),
+      );
+
+      const { status, body } = await request(app).get('/entity.yaml');
+
+      expect(mockGetAllYaml).toHaveBeenCalledTimes(1);
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!' },
+      });
+    });
+  });
+  describe('GET /:name/entity.yaml', () => {
+    it('Should call getYaml', async () => {
+      const { app, mockGetYaml } = await setup();
+      mockGetYaml.mockImplementationOnce((req, res) =>
+        res.status(200).json({ result: 'Success!', name: req.params.name }),
+      );
+
+      const { status, body } = await request(app).get(
+        '/core-defra/entity.yaml',
+      );
+
+      expect(mockGetYaml).toHaveBeenCalledTimes(1);
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!', name: 'core-defra' },
+      });
+    });
+  });
+  describe('GET /health', () => {
+    it('Should call health', async () => {
+      const { app, mockHealth } = await setup();
+      mockHealth.mockImplementationOnce((_, res) =>
+        res.status(200).json({ result: 'Success!' }),
+      );
+
+      const { status, body } = await request(app).get('/health');
+
+      expect(mockHealth).toHaveBeenCalledTimes(1);
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!' },
+      });
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/index.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-programmes/index.ts
@@ -1,0 +1,20 @@
+import { createRouterRef } from '../../util';
+import getAllYaml from './getAll.yaml';
+import getYaml from './get.yaml';
+import health from './health';
+import { middlewareFactoryRef } from '../../../refs';
+
+export default createRouterRef({
+  deps: {
+    middleware: middlewareFactoryRef,
+    getAllYaml,
+    getYaml,
+    health,
+  },
+  factory({ router, deps }) {
+    router.get('/entity.yaml', deps.getAllYaml);
+    router.get('/:name/entity.yaml', deps.getYaml);
+    router.get('/health', deps.health);
+    router.use(deps.middleware.error());
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-projects/get.yaml.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-projects/get.yaml.test.ts
@@ -1,0 +1,135 @@
+import {
+  type IDeliveryProgrammeStore,
+  deliveryProgrammeStoreRef,
+} from '../../../deliveryProgramme';
+import {
+  type IDeliveryProjectStore,
+  deliveryProjectStoreRef,
+} from '../../../deliveryProject';
+import {
+  type IDeliveryProjectUserStore,
+  deliveryProjectUserStoreRef,
+} from '../../../deliveryProjectUser';
+import getYaml from './get.yaml';
+import { testHelpers } from '../../../utils/testHelpers';
+import request from 'supertest';
+import { randomUUID } from 'node:crypto';
+
+describe('default', () => {
+  async function setup() {
+    const programmes: jest.Mocked<IDeliveryProgrammeStore> = {
+      add: jest.fn(),
+      get: jest.fn(),
+      getAll: jest.fn(),
+      update: jest.fn(),
+      getByName: jest.fn(),
+    };
+    const projects: jest.Mocked<IDeliveryProjectStore> = {
+      add: jest.fn(),
+      getAll: jest.fn(),
+      get: jest.fn(),
+      getByName: jest.fn(),
+      update: jest.fn(),
+    };
+    const projectUsers: jest.Mocked<IDeliveryProjectUserStore> = {
+      add: jest.fn(),
+      delete: jest.fn(),
+      get: jest.fn(),
+      getAll: jest.fn(),
+      getByDeliveryProject: jest.fn(),
+      update: jest.fn(),
+    };
+
+    const handler = await testHelpers.getAutoServiceRef(getYaml, [
+      testHelpers.provideService(deliveryProgrammeStoreRef, programmes),
+      testHelpers.provideService(deliveryProjectStoreRef, projects),
+      testHelpers.provideService(deliveryProjectUserStoreRef, projectUsers),
+    ]);
+
+    const app = testHelpers.makeApp(x => x.get('/:name/entity.yaml', handler));
+
+    return { handler, app, programmes, projects, projectUsers };
+  }
+
+  it('Should return ok with the data from the store', async () => {
+    const { app, programmes, projects, projectUsers } = await setup();
+    const programmeId = randomUUID();
+    const projectId = randomUUID();
+    projects.getByName.mockResolvedValueOnce({
+      delivery_programme_id: programmeId,
+      id: projectId,
+      created_at: new Date(),
+      ado_project: randomUUID(),
+      delivery_programme_admins: [],
+      delivery_programme_code: 'ABC',
+      delivery_project_code: 'DEF',
+      delivery_project_users: [],
+      description: 'My test delivery project',
+      name: 'abc-test-project',
+      namespace: 'abc-test-project',
+      service_owner: randomUUID(),
+      team_type: randomUUID(),
+      title: 'Test Project',
+      updated_at: new Date(),
+      alias: 'XYZ',
+    });
+    programmes.get.mockResolvedValueOnce({
+      name: 'test-programme',
+      created_at: new Date(),
+      updated_at: new Date(),
+      arms_length_body_id: randomUUID(),
+      delivery_programme_admins: [],
+      delivery_programme_code: randomUUID(),
+      description: randomUUID(),
+      id: randomUUID(),
+      title: randomUUID(),
+    });
+    projectUsers.getByDeliveryProject.mockResolvedValueOnce(
+      ['admin.1@email.com', 'admin.2@email.com'].map(email => ({
+        aad_entity_ref_id: randomUUID(),
+        delivery_project_id: randomUUID(),
+        email,
+        id: randomUUID(),
+        name: randomUUID(),
+        updated_at: new Date(),
+        is_admin: true,
+        is_technical: true,
+      })),
+    );
+
+    const {
+      status,
+      text,
+      header: { 'content-type': contentType },
+    } = await request(app).get(`/test-project/entity.yaml`);
+
+    expect(projects.getByName).toHaveBeenCalledTimes(1);
+    expect(projects.getByName).toHaveBeenCalledWith('test-project');
+    expect(programmes.get).toHaveBeenCalledTimes(1);
+    expect(programmes.get).toHaveBeenCalledWith(programmeId);
+    expect(projectUsers.getByDeliveryProject).toHaveBeenCalledTimes(1);
+    expect(projectUsers.getByDeliveryProject).toHaveBeenCalledWith(projectId);
+    expect({ status, text, contentType }).toMatchObject({
+      status: 200,
+      contentType: 'application/yaml',
+      text: `apiVersion: backstage.io/v1beta1
+kind: Group
+metadata:
+  name: abc-test-project
+  title: ABC Test Project (XYZ)
+  description: My test delivery project
+  tags: []
+  links: []
+  annotations:
+    adp.defra.gov.uk/delivery-project-id: ${projectId}
+spec:
+  type: delivery-project
+  parent: group:default/test-programme
+  members:
+    - admin.1_email.com
+    - admin.2_email.com
+  children: []
+`,
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-projects/get.yaml.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-projects/get.yaml.ts
@@ -1,0 +1,64 @@
+import { type GroupEntity } from '@backstage/catalog-model';
+import type { Request } from 'express';
+import { deliveryProgrammeStoreRef } from '../../../deliveryProgramme';
+import { createEndpointRef } from '../../util';
+import {
+  DELIVERY_PROJECT_ID_ANNOTATION,
+  createTransformerTitle,
+} from '../util';
+import {
+  deliveryProjectDisplayName,
+  normalizeUsername,
+} from '@internal/plugin-adp-common';
+import { deliveryProjectStoreRef } from '../../../deliveryProject';
+import { deliveryProjectUserStoreRef } from '../../../deliveryProjectUser';
+
+export default createEndpointRef({
+  deps: {
+    deliveryProgrammeStore: deliveryProgrammeStoreRef,
+    deliveryProjectStore: deliveryProjectStoreRef,
+    deliveryProjectUserStore: deliveryProjectUserStoreRef,
+  },
+  factory({
+    deps: {
+      deliveryProgrammeStore,
+      deliveryProjectStore,
+      deliveryProjectUserStore,
+    },
+    responses: { ok },
+  }) {
+    return async (request: Request<{ name: string }>) => {
+      const entity = await deliveryProjectStore.getByName(request.params.name);
+      const parent = await deliveryProgrammeStore.get(
+        entity.delivery_programme_id,
+      );
+      const children = await deliveryProjectUserStore.getByDeliveryProject(
+        entity.id,
+      );
+
+      return ok().yaml({
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Group',
+        metadata: {
+          name: entity.name,
+          title: createTransformerTitle(
+            deliveryProjectDisplayName(entity),
+            entity.alias,
+          ),
+          description: entity.description,
+          tags: [],
+          links: [],
+          annotations: {
+            [DELIVERY_PROJECT_ID_ANNOTATION]: entity.id,
+          },
+        },
+        spec: {
+          type: 'delivery-project',
+          parent: `group:default/${parent.name}`,
+          members: children.map(m => normalizeUsername(m.email)),
+          children: [],
+        },
+      } satisfies GroupEntity);
+    };
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-projects/getAll.yaml.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-projects/getAll.yaml.test.ts
@@ -1,0 +1,74 @@
+import getAllYaml from './getAll.yaml';
+import { testHelpers } from '../../../utils/testHelpers';
+import request from 'supertest';
+import { coreServices } from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
+import {
+  type IDeliveryProjectStore,
+  deliveryProjectStoreRef,
+} from '../../../deliveryProject';
+import type { DeliveryProject } from '@internal/plugin-adp-common';
+
+describe('default', () => {
+  async function setup() {
+    const config = mockServices.rootConfig({
+      data: {
+        app: {
+          baseUrl: 'http://defra-adp:3000',
+        },
+      },
+    });
+
+    const projects: jest.Mocked<IDeliveryProjectStore> = {
+      add: jest.fn(),
+      get: jest.fn(),
+      getAll: jest.fn(),
+      update: jest.fn(),
+      getByName: jest.fn(),
+    };
+
+    const handler = await testHelpers.getAutoServiceRef(getAllYaml, [
+      testHelpers.provideService(deliveryProjectStoreRef, projects),
+      testHelpers.provideService(coreServices.rootConfig, config),
+    ]);
+
+    const app = testHelpers.makeApp(x => x.get('/index.yaml', handler));
+
+    return { handler, app, projects };
+  }
+
+  it('Should return ok with the data from the store', async () => {
+    const { app, projects } = await setup();
+    projects.getAll.mockResolvedValueOnce([
+      { name: 'project-1' },
+      { name: 'project-2' },
+      { name: 'project-3' },
+      { name: 'project-4' },
+    ] as Partial<DeliveryProject>[] as DeliveryProject[]);
+
+    const {
+      status,
+      text,
+      header: { 'content-type': contentType },
+    } = await request(app).get(`/index.yaml`);
+
+    expect(projects.getAll).toHaveBeenCalledTimes(1);
+    expect({ status, text, contentType }).toMatchObject({
+      status: 200,
+      contentType: 'application/yaml',
+      text: `apiVersion: backstage.io/v1beta1
+kind: Location
+metadata:
+  name: delivery-projects
+  description: All the delivery projects available in the system
+spec:
+  type: url
+  targets:
+    - http://defra-adp:3000/onboarding/delivery-projects/project-1
+    - http://defra-adp:3000/onboarding/delivery-projects/project-2
+    - http://defra-adp:3000/onboarding/delivery-projects/project-3
+    - http://defra-adp:3000/onboarding/delivery-projects/project-4
+`,
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-projects/getAll.yaml.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-projects/getAll.yaml.ts
@@ -1,0 +1,30 @@
+import type { LocationEntity } from '@backstage/catalog-model';
+import { deliveryProjectStoreRef } from '../../../deliveryProject';
+import { createEndpointRef } from '../../util';
+import { coreServices } from '@backstage/backend-plugin-api';
+
+export default createEndpointRef({
+  deps: {
+    deliveryProjectStore: deliveryProjectStoreRef,
+    config: coreServices.rootConfig,
+  },
+  factory({ deps: { deliveryProjectStore, config }, responses: { ok } }) {
+    const baseUrl = `${config.getString('app.baseUrl')}/onboarding`;
+    return async () => {
+      const entities = await deliveryProjectStore.getAll();
+
+      return ok().yaml({
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Location',
+        metadata: {
+          name: 'delivery-projects',
+          description: 'All the delivery projects available in the system',
+        },
+        spec: {
+          type: 'url',
+          targets: entities.map(p => `${baseUrl}/delivery-projects/${p.name}`),
+        },
+      } satisfies LocationEntity);
+    };
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-projects/health.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-projects/health.test.ts
@@ -1,0 +1,40 @@
+import health from './health';
+import { testHelpers } from '../../../utils/testHelpers';
+import request from 'supertest';
+import {
+  type LoggerService,
+  coreServices,
+} from '@backstage/backend-plugin-api';
+
+describe('default', () => {
+  async function setup() {
+    const logger: jest.Mocked<LoggerService> = {
+      child: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    };
+
+    const handler = await testHelpers.getAutoServiceRef(health, [
+      testHelpers.provideService(coreServices.logger, logger),
+    ]);
+
+    const app = testHelpers.makeApp(x => x.get('/', handler));
+
+    return { handler, app, logger };
+  }
+
+  it('Log pong and return 200 ok', async () => {
+    const { app, logger } = await setup();
+
+    const { status, body } = await request(app).get(`/`);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('PONG!');
+    expect({ status, body }).toMatchObject({
+      status: 200,
+      body: { status: 'ok' },
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-projects/health.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-projects/health.ts
@@ -1,0 +1,14 @@
+import { coreServices } from '@backstage/backend-plugin-api';
+import { createEndpointRef } from '../../util';
+
+export default createEndpointRef({
+  deps: {
+    logger: coreServices.logger,
+  },
+  factory({ deps: { logger }, responses: { ok } }) {
+    return () => {
+      logger.info('PONG!');
+      return ok().json({ status: 'ok' });
+    };
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-projects/index.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-projects/index.test.ts
@@ -1,0 +1,89 @@
+import express from 'express';
+import { testHelpers } from '../../../utils/testHelpers';
+import index from './index';
+import health from './health';
+import request from 'supertest';
+import getAllYaml from './getAll.yaml';
+import getYaml from './get.yaml';
+
+describe('default', () => {
+  async function setup() {
+    function mockHandler<T extends (...args: never) => unknown>() {
+      return jest.fn(() => {
+        throw new Error('Unexpected call');
+      }) as unknown as jest.MockedFn<T>;
+    }
+
+    const mockGetAllYaml = mockHandler<(typeof getAllYaml)['T']>();
+    const mockGetYaml = mockHandler<(typeof getYaml)['T']>();
+    const mockHealth = mockHandler<(typeof health)['T']>();
+
+    const handler = await testHelpers.getAutoServiceRef(index, [
+      testHelpers.provideService(getAllYaml, mockGetAllYaml),
+      testHelpers.provideService(getYaml, mockGetYaml),
+      testHelpers.provideService(health, mockHealth),
+    ]);
+
+    const app = express();
+    app.use(handler);
+
+    return {
+      handler,
+      app,
+      mockGetAllYaml,
+      mockGetYaml,
+      mockHealth,
+    };
+  }
+
+  describe('GET /entity.yaml', () => {
+    it('Should call getAllYaml', async () => {
+      const { app, mockGetAllYaml } = await setup();
+      mockGetAllYaml.mockImplementationOnce((_, res) =>
+        res.status(200).json({ result: 'Success!' }),
+      );
+
+      const { status, body } = await request(app).get('/entity.yaml');
+
+      expect(mockGetAllYaml).toHaveBeenCalledTimes(1);
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!' },
+      });
+    });
+  });
+  describe('GET /:name/entity.yaml', () => {
+    it('Should call getYaml', async () => {
+      const { app, mockGetYaml } = await setup();
+      mockGetYaml.mockImplementationOnce((req, res) =>
+        res.status(200).json({ result: 'Success!', name: req.params.name }),
+      );
+
+      const { status, body } = await request(app).get(
+        '/core-defra/entity.yaml',
+      );
+
+      expect(mockGetYaml).toHaveBeenCalledTimes(1);
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!', name: 'core-defra' },
+      });
+    });
+  });
+  describe('GET /health', () => {
+    it('Should call health', async () => {
+      const { app, mockHealth } = await setup();
+      mockHealth.mockImplementationOnce((_, res) =>
+        res.status(200).json({ result: 'Success!' }),
+      );
+
+      const { status, body } = await request(app).get('/health');
+
+      expect(mockHealth).toHaveBeenCalledTimes(1);
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!' },
+      });
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/delivery-projects/index.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/delivery-projects/index.ts
@@ -1,0 +1,20 @@
+import { createRouterRef } from '../../util';
+import getAllYaml from './getAll.yaml';
+import getYaml from './get.yaml';
+import health from './health';
+import { middlewareFactoryRef } from '../../../refs';
+
+export default createRouterRef({
+  deps: {
+    middleware: middlewareFactoryRef,
+    getAllYaml,
+    getYaml,
+    health,
+  },
+  factory({ router, deps }) {
+    router.get('/entity.yaml', deps.getAllYaml);
+    router.get('/:name/entity.yaml', deps.getYaml);
+    router.get('/health', deps.health);
+    router.use(deps.middleware.error());
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/index.test.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/index.test.ts
@@ -1,0 +1,76 @@
+import express, { Router } from 'express';
+import { testHelpers } from '../../utils/testHelpers';
+import index from './index';
+import request from 'supertest';
+import armsLengthBodies from './arms-length-bodies';
+import deliveryProgrammes from './delivery-programmes';
+import deliveryProjects from './delivery-projects';
+
+describe('default', () => {
+  async function setup() {
+    const albs = Router();
+    const programmes = Router();
+    const projects = Router();
+
+    const handler = await testHelpers.getAutoServiceRef(index, [
+      testHelpers.provideService(armsLengthBodies, albs),
+      testHelpers.provideService(deliveryProgrammes, programmes),
+      testHelpers.provideService(deliveryProjects, projects),
+    ]);
+
+    const app = express();
+    app.use(handler);
+
+    return {
+      handler,
+      app,
+      albs,
+      programmes,
+      projects,
+    };
+  }
+  describe('GET /arms-length-bodies', () => {
+    it('Should call armsLengthBodies', async () => {
+      const { app, albs } = await setup();
+      albs.get('/', (_, res) => res.status(200).json({ result: 'Success!' }));
+
+      const { status, body } = await request(app).get('/arms-length-bodies');
+
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!' },
+      });
+    });
+  });
+
+  describe('GET /delivery-programmes', () => {
+    it('Should call deliveryProgrammes', async () => {
+      const { app, programmes } = await setup();
+      programmes.get('/', (_, res) =>
+        res.status(200).json({ result: 'Success!' }),
+      );
+
+      const { status, body } = await request(app).get('/delivery-programmes');
+
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!' },
+      });
+    });
+  });
+  describe('GET /delivery-projects', () => {
+    it('Should call deliveryProjects', async () => {
+      const { app, projects } = await setup();
+      projects.get('/', (_, res) =>
+        res.status(200).json({ result: 'Success!' }),
+      );
+
+      const { status, body } = await request(app).get('/delivery-projects');
+
+      expect({ status, body }).toMatchObject({
+        status: 200,
+        body: { result: 'Success!' },
+      });
+    });
+  });
+});

--- a/app/plugins/adp-backend/src/routes/catalog/index.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/index.ts
@@ -1,0 +1,17 @@
+import { createRouterRef } from '../util';
+import armsLengthBodies from './arms-length-bodies';
+import deliveryProgrammes from './delivery-programmes';
+import deliveryProjects from './delivery-projects';
+
+export default createRouterRef({
+  deps: {
+    armsLengthBodies,
+    deliveryProgrammes,
+    deliveryProjects,
+  },
+  factory({ router, deps }) {
+    router.use('/arms-length-bodies', deps.armsLengthBodies);
+    router.use('/delivery-programmes', deps.deliveryProgrammes);
+    router.use('/delivery-projects', deps.deliveryProjects);
+  },
+});

--- a/app/plugins/adp-backend/src/routes/catalog/util.ts
+++ b/app/plugins/adp-backend/src/routes/catalog/util.ts
@@ -1,0 +1,10 @@
+export function createTransformerTitle(title: string, alias?: string) {
+  const titleValue = alias ? `${title} ` + `(${alias})` : title;
+  return titleValue;
+}
+export const ARMS_LENGTH_BODY_ID_ANNOTATION =
+  'adp.defra.gov.uk/arms-length-body-id';
+export const DELIVERY_PROGRAMME_ID_ANNOTATION =
+  'adp.defra.gov.uk/delivery-programme-id';
+export const DELIVERY_PROJECT_ID_ANNOTATION =
+  'adp.defra.gov.uk/delivery-project-id';

--- a/app/plugins/adp-backend/src/routes/deliveryProgrammeAdmins/index.ts
+++ b/app/plugins/adp-backend/src/routes/deliveryProgrammeAdmins/index.ts
@@ -32,6 +32,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { createRouterRef } from '../util';
 import { catalogApiRef, middlewareFactoryRef } from '../../refs';
+import { fireAndForgetCatalogRefresherRef } from '../../services';
 
 export interface DeliveryProgrammeAdminRouterOptions {
   logger: LoggerService;
@@ -53,6 +54,7 @@ export default createRouterRef({
     auth: coreServices.auth,
     permissions: coreServices.permissions,
     middleware: middlewareFactoryRef,
+    catalogRefresher: fireAndForgetCatalogRefresherRef,
   },
   factory({
     router,
@@ -64,6 +66,7 @@ export default createRouterRef({
       httpAuth,
       auth,
       middleware,
+      catalogRefresher,
     },
   }) {
     const {
@@ -155,6 +158,7 @@ export default createRouterRef({
       };
 
       const addedUser = await deliveryProgrammeAdminStore.add(addUser);
+      await catalogRefresher.refresh(`location:default/delivery-programmes`);
       respond(body, res, addedUser, errorMapping, { ok: 201 });
     });
 
@@ -181,6 +185,7 @@ export default createRouterRef({
         `DELETE /: Deleted Delivery Programme Admin with ID ${body.delivery_programme_admin_id}`,
       );
 
+      await catalogRefresher.refresh(`location:default/delivery-programmes`);
       res.status(204).end();
     });
 

--- a/app/plugins/adp-backend/src/routes/deliveryProgrammes/index.ts
+++ b/app/plugins/adp-backend/src/routes/deliveryProgrammes/index.ts
@@ -35,6 +35,7 @@ import {
 import { deliveryProjectStoreRef } from '../../deliveryProject';
 import type { UUID } from 'node:crypto';
 import { stringifyEntityRef } from '@backstage/catalog-model';
+import { fireAndForgetCatalogRefresherRef } from '../../services';
 
 export default createRouterRef({
   deps: {
@@ -48,6 +49,7 @@ export default createRouterRef({
     auth: coreServices.auth,
     permissions: coreServices.permissions,
     middleware: middlewareFactoryRef,
+    catalogRefresher: fireAndForgetCatalogRefresherRef,
   },
   factory({
     router,
@@ -62,6 +64,7 @@ export default createRouterRef({
       auth,
       permissions,
       middleware,
+      catalogRefresher,
     },
   }) {
     const {
@@ -162,6 +165,7 @@ export default createRouterRef({
         };
         await deliveryProgrammeAdminStore.add(addUser);
       }
+      await catalogRefresher.refresh(`location:default/delivery-programmes`);
       respond(body, res, result, errorMapping, { ok: 201 });
     });
 
@@ -180,6 +184,7 @@ export default createRouterRef({
       );
       const creator = await getCurrentUsername(identity, req);
       const result = await deliveryProgrammeStore.update(body, creator);
+      await catalogRefresher.refresh(`location:default/delivery-programmes`);
       respond(body, res, result, errorMapping);
     });
 

--- a/app/plugins/adp-backend/src/routes/deliveryProjectUsers/index.ts
+++ b/app/plugins/adp-backend/src/routes/deliveryProjectUsers/index.ts
@@ -41,6 +41,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { createRouterRef } from '../util';
 import { catalogApiRef, middlewareFactoryRef } from '../../refs';
+import { fireAndForgetCatalogRefresherRef } from '../../services';
 
 export interface DeliveryProjectUserRouterOptions {
   logger: LoggerService;
@@ -64,6 +65,7 @@ export default createRouterRef({
     httpAuth: coreServices.httpAuth,
     auth: coreServices.auth,
     middleware: middlewareFactoryRef,
+    catalogRefresher: fireAndForgetCatalogRefresherRef,
   },
   factory({
     router,
@@ -76,6 +78,7 @@ export default createRouterRef({
       httpAuth,
       auth,
       middleware,
+      catalogRefresher,
     },
   }) {
     const {
@@ -162,6 +165,7 @@ export default createRouterRef({
         ]);
       }
 
+      await catalogRefresher.refresh(`location:default/delivery-programmes`);
       respond(body, res, addedUser, errorMapping, { ok: 201 });
     });
 
@@ -223,6 +227,8 @@ export default createRouterRef({
           ),
         ]);
       }
+
+      await catalogRefresher.refresh(`location:default/delivery-programmes`);
       respond(body, res, result, errorMapping);
     });
 
@@ -248,6 +254,7 @@ export default createRouterRef({
         entraIdGroupSyncronizer.syncronizeById(body.delivery_project_id),
       ]);
 
+      await catalogRefresher.refresh(`location:default/delivery-programmes`);
       res.status(204).end();
     });
 

--- a/app/plugins/adp-backend/src/routes/deliveryProjects/index.ts
+++ b/app/plugins/adp-backend/src/routes/deliveryProjects/index.ts
@@ -34,6 +34,7 @@ import {
   getCurrentUsername,
   respond,
 } from '../../utils';
+import { fireAndForgetCatalogRefresherRef } from '../../services';
 
 export default createRouterRef({
   deps: {
@@ -49,6 +50,7 @@ export default createRouterRef({
     httpAuth: coreServices.httpAuth,
     permissions: coreServices.permissions,
     middleware: middlewareFactoryRef,
+    catalogRefresher: fireAndForgetCatalogRefresherRef,
   },
   factory({
     router,
@@ -65,6 +67,7 @@ export default createRouterRef({
       httpAuth,
       permissions,
       middleware,
+      catalogRefresher,
     },
   }) {
     const {
@@ -128,6 +131,7 @@ export default createRouterRef({
           teamSyncronizer.syncronizeByName(result.value.name),
         ]);
       }
+      await catalogRefresher.refresh(`location:default/delivery-programmes`);
       respond(body, res, result, errorMapping, { ok: 201 });
     });
 
@@ -151,6 +155,7 @@ export default createRouterRef({
           teamSyncronizer.syncronizeByName(result.value.name),
         ]);
       }
+      await catalogRefresher.refresh(`location:default/delivery-programmes`);
       respond(body, res, result, errorMapping);
     });
 

--- a/app/plugins/adp-backend/src/routes/index.ts
+++ b/app/plugins/adp-backend/src/routes/index.ts
@@ -6,6 +6,7 @@ import deliveryProgrammes from './deliveryProgrammes';
 import deliveryProjects from './deliveryProjects';
 import deliveryProgrammeAdmins from './deliveryProgrammeAdmins';
 import deliveryProjectUsers from './deliveryProjectUsers';
+import catalog from './catalog';
 
 export default createRouterRef({
   deps: {
@@ -16,10 +17,12 @@ export default createRouterRef({
     deliveryProjects,
     deliveryProgrammeAdmins,
     deliveryProjectUsers,
+    catalog,
   },
   factory({ router, deps }) {
     router.use(deps.auth);
     router.use(deps.credentialsContextMiddleware);
+    router.use('/catalog', deps.catalog);
     router.use('/armsLengthBodies', deps.armsLengthBodies);
     router.use('/deliveryProgrammes', deps.deliveryProgrammes);
     router.use('/deliveryProjects', deps.deliveryProjects);

--- a/app/plugins/adp-backend/src/routes/util/HandlerResult.ts
+++ b/app/plugins/adp-backend/src/routes/util/HandlerResult.ts
@@ -1,5 +1,6 @@
 import type { Response } from 'express';
 import type { Readable } from 'node:stream';
+import yaml from 'yaml';
 
 export interface HandlerResult {
   writeTo(response: Response): void | PromiseLike<void>;
@@ -50,6 +51,12 @@ export class FluentHandlerResult implements HandlerResult {
       response.json(body);
     });
     return this;
+  }
+
+  yaml(body: unknown) {
+    if (!this.#headers.has('content-type'))
+      this.#headers.set('content-type', 'application/yaml');
+    return this.text(yaml.stringify(body));
   }
 
   text(body: string) {

--- a/app/plugins/adp-backend/src/services/fireAndForgetCatalogRefresher.ts
+++ b/app/plugins/adp-backend/src/services/fireAndForgetCatalogRefresher.ts
@@ -1,0 +1,52 @@
+import {
+  coreServices,
+  createServiceFactory,
+  createServiceRef,
+} from '@backstage/backend-plugin-api';
+import { catalogApiRef } from '../refs';
+import { assertError } from '@backstage/errors';
+import type { CatalogRequestOptions } from '@backstage/catalog-client';
+
+export interface FireAndForgetCatalogRefresher {
+  refresh(entityRef: string, options?: CatalogRequestOptions): Promise<void>;
+}
+
+export const fireAndForgetCatalogRefresherRef =
+  createServiceRef<FireAndForgetCatalogRefresher>({
+    id: 'adp.fire-and-forget-catalog-refresher',
+    scope: 'plugin',
+    defaultFactory(service) {
+      return Promise.resolve(
+        createServiceFactory({
+          service,
+          deps: {
+            auth: coreServices.auth,
+            catalog: catalogApiRef,
+            logger: coreServices.logger,
+          },
+          factory({ catalog, auth, logger }) {
+            return {
+              async refresh(entityRef, options) {
+                try {
+                  const creds = await auth.getPluginRequestToken({
+                    onBehalfOf: await auth.getOwnServiceCredentials(),
+                    targetPluginId: 'catalog',
+                  });
+                  await catalog.refreshEntity(entityRef, {
+                    ...creds,
+                    ...options,
+                  });
+                } catch (err) {
+                  assertError(err);
+                  logger.error(
+                    `Error while refreshing catalog entity ${entityRef}`,
+                    err,
+                  );
+                }
+              },
+            };
+          },
+        }),
+      );
+    },
+  });

--- a/app/plugins/adp-backend/src/services/index.ts
+++ b/app/plugins/adp-backend/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from './fireAndForgetCatalogRefresher';

--- a/app/plugins/catalog-backend-module-adp/src/module.test.ts
+++ b/app/plugins/catalog-backend-module-adp/src/module.test.ts
@@ -1,11 +1,7 @@
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
-import type { AdpDatabaseEntityProvider } from './providers';
 import fetchApiFactory from '@internal/plugin-fetch-api-backend';
 import type { CatalogPermissionRuleInput } from '@backstage/plugin-catalog-node/alpha';
-import {
-  catalogPermissionExtensionPoint,
-  catalogProcessingExtensionPoint,
-} from '@backstage/plugin-catalog-node/alpha';
+import { catalogPermissionExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { adpCatalogModule } from './module';
 import type { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import type { UserTransformer } from '@backstage/plugin-catalog-backend-module-msgraph';
@@ -13,17 +9,11 @@ import { microsoftGraphOrgEntityProviderTransformExtensionPoint } from '@backsta
 
 describe('catalogModuleAdpEntityProvider', () => {
   it('should register the provider with the catalog extension point', async () => {
-    let addedProvider: AdpDatabaseEntityProvider | undefined;
     let addedPermissionRules:
       | CatalogPermissionRuleInput<PermissionRuleParams>[][]
       | undefined;
     let configuredTransformer: UserTransformer | undefined;
 
-    const processingExtensionPont = {
-      addEntityProvider: (providers: any) => {
-        addedProvider = providers;
-      },
-    };
     const permissionsExtensionPont = {
       addPermissionRules: (...rules: any) => {
         addedPermissionRules = rules;
@@ -41,7 +31,6 @@ describe('catalogModuleAdpEntityProvider', () => {
 
     await startTestBackend({
       extensionPoints: [
-        [catalogProcessingExtensionPoint, processingExtensionPont],
         [catalogPermissionExtensionPoint, permissionsExtensionPont],
         [
           microsoftGraphOrgEntityProviderTransformExtensionPoint,
@@ -56,11 +45,6 @@ describe('catalogModuleAdpEntityProvider', () => {
         fetchApiFactory(),
       ],
     });
-
-    expect(addedProvider).toBeDefined();
-    expect(addedProvider?.getProviderName()).toEqual(
-      'AdpDatabaseEntityProvider',
-    );
 
     expect(addedPermissionRules).toBeDefined();
     expect(addedPermissionRules?.pop()?.pop()?.name).toBe('IS_GROUP_MEMBER');

--- a/app/plugins/catalog-backend-module-adp/src/module.ts
+++ b/app/plugins/catalog-backend-module-adp/src/module.ts
@@ -1,13 +1,5 @@
-import {
-  coreServices,
-  createBackendModule,
-} from '@backstage/backend-plugin-api';
-import {
-  catalogPermissionExtensionPoint,
-  catalogProcessingExtensionPoint,
-} from '@backstage/plugin-catalog-node/alpha';
-import { AdpDatabaseEntityProvider } from './providers';
-import { fetchApiRef } from '@internal/plugin-fetch-api-backend';
+import { createBackendModule } from '@backstage/backend-plugin-api';
+import { catalogPermissionExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { isGroupMemberRule } from './permissions';
 import { microsoftGraphOrgEntityProviderTransformExtensionPoint } from '@backstage/plugin-catalog-backend-module-msgraph/alpha';
 import { defraUserNameTransformer } from './transformers/defraUserNameTransformer';
@@ -18,36 +10,11 @@ export const adpCatalogModule = createBackendModule({
   register(reg) {
     reg.registerInit({
       deps: {
-        logger: coreServices.logger,
-        discovery: coreServices.discovery,
-        scheduler: coreServices.scheduler,
-        catalogProcessing: catalogProcessingExtensionPoint,
         catalogPermissions: catalogPermissionExtensionPoint,
         microsoftGraphTransformers:
           microsoftGraphOrgEntityProviderTransformExtensionPoint,
-        auth: coreServices.auth,
-        fetchApi: fetchApiRef,
       },
-      async init({
-        logger,
-        catalogProcessing,
-        catalogPermissions,
-        microsoftGraphTransformers,
-        discovery,
-        scheduler,
-        auth,
-        fetchApi,
-      }) {
-        catalogProcessing.addEntityProvider(
-          AdpDatabaseEntityProvider.create({
-            discovery,
-            logger: logger,
-            scheduler: scheduler,
-            fetchApi,
-            auth,
-          }),
-        );
-
+      async init({ catalogPermissions, microsoftGraphTransformers }) {
         catalogPermissions.addPermissionRules([isGroupMemberRule]);
 
         microsoftGraphTransformers.setUserTransformer(defraUserNameTransformer);

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -6629,6 +6629,7 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.1.0"
     supertest: "npm:^6.2.4"
+    yaml: "npm:^2.4.3"
     zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
…n demand

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<AB#213700>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. AB#213700 (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
AB#371568 Implement a new method for loading in entities from the adp database which allows for entities to be refreshed on demand. The way entities are loaded now is via 1 of the 3 new locations added to the app-config.yaml. These new locations are read by a custom URL reader which calls one of the new backend apis. This results in a refreshable location entitiy which points to the actual entities to be loaded later.
Currently, refreshing can only be done at the all alb/programme/project level. We might want to look at refining this to be at the level of individual entities at a later date.

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# **How does this PR make you feel**:
![gif]([https://giphy.com/)