### PR TITLE
397708: Bug fix - creator of programme can now edit 

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "private": true,
   "packageManager": "yarn@4.3.1",
   "engines": {

--- a/app/plugins/adp-backend/src/routes/deliveryProgrammes/index.test.ts
+++ b/app/plugins/adp-backend/src/routes/deliveryProgrammes/index.test.ts
@@ -239,7 +239,7 @@ describe('createRouter', () => {
         delivery_programme_id: '',
         email: 'test1.test@onmicrosoft.com',
         name: 'test1',
-        user_entity_ref: 'user:default/unknown',
+        user_entity_ref: 'unknown',
       };
       // assert
       expect(response.status).toEqual(201);

--- a/app/plugins/adp-backend/src/routes/deliveryProgrammes/index.ts
+++ b/app/plugins/adp-backend/src/routes/deliveryProgrammes/index.ts
@@ -34,7 +34,6 @@ import {
 } from '../../deliveryProgrammeAdmin';
 import { deliveryProjectStoreRef } from '../../deliveryProject';
 import type { UUID } from 'node:crypto';
-import { stringifyEntityRef } from '@backstage/catalog-model';
 
 export default createRouterRef({
   deps: {
@@ -154,11 +153,7 @@ export default createRouterRef({
               'graph.microsoft.com/user-id'
             ],
           delivery_programme_id: result.value.id as UUID,
-          user_entity_ref: stringifyEntityRef({
-            kind: 'user',
-            namespace: 'default',
-            name: creator,
-          }),
+          user_entity_ref: creator,
         };
         await deliveryProgrammeAdminStore.add(addUser);
       }

--- a/app/plugins/adp-backend/src/routes/deliveryProgrammes/index.ts
+++ b/app/plugins/adp-backend/src/routes/deliveryProgrammes/index.ts
@@ -34,7 +34,6 @@ import {
 } from '../../deliveryProgrammeAdmin';
 import { deliveryProjectStoreRef } from '../../deliveryProject';
 import type { UUID } from 'node:crypto';
-import { stringifyEntityRef } from '@backstage/catalog-model';
 
 export default createRouterRef({
   deps: {
@@ -154,11 +153,7 @@ export default createRouterRef({
               'graph.microsoft.com/user-id'
             ],
           delivery_programme_id: result.value.id as UUID,
-          user_entity_ref: stringifyEntityRef({
-            kind: 'user',
-            namespace: 'default',
-            name: creatorName,
-          }),
+          user_entity_ref: creator,
         };
         await deliveryProgrammeAdminStore.add(addUser);
       }

--- a/app/plugins/adp-backend/src/routes/deliveryProgrammes/index.ts
+++ b/app/plugins/adp-backend/src/routes/deliveryProgrammes/index.ts
@@ -34,6 +34,7 @@ import {
 } from '../../deliveryProgrammeAdmin';
 import { deliveryProjectStoreRef } from '../../deliveryProject';
 import type { UUID } from 'node:crypto';
+import { stringifyEntityRef } from '@backstage/catalog-model';
 
 export default createRouterRef({
   deps: {
@@ -153,7 +154,11 @@ export default createRouterRef({
               'graph.microsoft.com/user-id'
             ],
           delivery_programme_id: result.value.id as UUID,
-          user_entity_ref: creator,
+          user_entity_ref: stringifyEntityRef({
+            kind: 'user',
+            namespace: 'default',
+            name: creatorName,
+          }),
         };
         await deliveryProgrammeAdminStore.add(addUser);
       }


### PR DESCRIPTION
# **What this PR does / why we need it**:
A new bug was introduced with the previous fix: the creator of the programme automatically becomes an admin but they weren't able to edit. This was caused by a duplication of 'user:default' within the user id sent to create the user as admin. This PR will fix this issue.

[AB#397708](https://dev.azure.com/defragovuk/DEFRA-FFC/_workitems/edit/397708)
# **Special notes for your reviewer**
*Any specific actions or notes on review?* 

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [ ] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [ ] Title pattern should be `{work item number}: {title}`
- [ ] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests
- [ ] Version number in [package.json](https://github.com/DEFRA/adp-portal/blob/main/app/package.json#L3) has been updated

# Dependency check (tick or delete)
Have you updated any related templates, repositories or dependencies for new changes? We must ensure any dependencies like Software Templates are updated to include the latest changes to be scaffolded for all services where applicable.

- [ ] ADP Software Templates? - https://github.com/DEFRA/adp-software-templates
- [ ] ADP Portal Web API? https://github.com/DEFRA/adp-portal-api

# **How does this PR make you feel**:
![gif]([https://giphy.com/)