### PR TITLE
409357: Scaffolder autocomplete accessibility fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "private": true,
   "packageManager": "yarn@4.3.1",
   "engines": {

--- a/plugins/scaffolder-adp-react/src/components/DeliveryProjectPicker/__snapshots__/DeliveryProjectPicker.test.tsx.snap
+++ b/plugins/scaffolder-adp-react/src/components/DeliveryProjectPicker/__snapshots__/DeliveryProjectPicker.test.tsx.snap
@@ -137,7 +137,11 @@ exports[`DeliveryProjectPicker Should filter the results 1`] = `
     >
       <div>
         <div
-          style="position: relative; height: 36px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+          aria-labelledby="mui-0-label"
+          class="MuiAutocomplete-listbox"
+          id="mui-0-popup"
+          role="listbox"
+          style="position: relative; height: 54px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
         >
           <div
             style="height: 36px; width: 100%;"
@@ -960,7 +964,11 @@ exports[`DeliveryProjectPicker Should show all the options in the drop down 1`] 
     >
       <div>
         <div
-          style="position: relative; height: 342px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+          aria-labelledby="mui-0-label"
+          class="MuiAutocomplete-listbox"
+          id="mui-0-popup"
+          role="listbox"
+          style="position: relative; height: 378px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
         >
           <div
             style="height: 360px; width: 100%;"

--- a/plugins/scaffolder-adp-react/src/components/VirtualizedListbox.tsx
+++ b/plugins/scaffolder-adp-react/src/components/VirtualizedListbox.tsx
@@ -1,6 +1,6 @@
 // source: https://github.com/backstage/backstage/blob/v1.28.4/plugins/scaffolder/src/components/fields/VirtualizedListbox.tsx
 
-import React from 'react';
+import React, { createContext, useContext } from 'react';
 import { FixedSizeList, type ListChildComponentProps } from 'react-window';
 
 const renderRow = (props: ListChildComponentProps) => {
@@ -8,29 +8,37 @@ const renderRow = (props: ListChildComponentProps) => {
   return React.cloneElement(data[index], { style });
 };
 
+const outerItemContext = createContext({});
+const OuterElementType = React.forwardRef<HTMLDivElement>((props, ref) => {
+  const outerProps = useContext(outerItemContext);
+  return <div ref={ref} {...props} {...outerProps} />;
+});
+
 export const VirtualizedListbox = React.forwardRef<
   HTMLDivElement,
   { children?: React.ReactNode }
->((props, ref) => {
+>(function VirtualizedListbox(props, ref) {
+  const { children, ...rest } = props;
   const itemData = React.Children.toArray(props.children);
   const itemCount = itemData.length;
 
   const itemSize = 36;
-
-  const itemsToShow = Math.min(10, itemCount);
-  const height = Math.max(itemSize, itemsToShow * itemSize - 0.5 * itemSize);
+  const height = Math.min(itemSize * 10.5, itemSize * (itemCount + 0.5));
 
   return (
     <div ref={ref}>
-      <FixedSizeList
-        height={height}
-        itemData={itemData}
-        itemCount={itemCount}
-        itemSize={itemSize}
-        width="100%"
-      >
-        {renderRow}
-      </FixedSizeList>
+      <outerItemContext.Provider value={rest}>
+        <FixedSizeList
+          height={height}
+          itemData={itemData}
+          itemCount={itemCount}
+          itemSize={itemSize}
+          outerElementType={OuterElementType}
+          width="100%"
+        >
+          {renderRow}
+        </FixedSizeList>
+      </outerItemContext.Provider>
     </div>
   );
 });


### PR DESCRIPTION
# **What this PR does / why we need it**:
[AB#409357](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/409357) Fixes the autocomplete accessibility issue by forwarding the relevant properties from the autocomplete to the listbox. Fix is based on the example implementation done in the [MUI docs](https://v4.mui.com/components/autocomplete/#virtualization). This fix only applies to the owner drop down. The system drop down is still using the out of the box react component which has this issue.

# **Special notes for your reviewer**

_Any specific actions or notes on review?_

# Testing

_Any relevant testing information and pipeline runs._

# **How does this PR make you feel**:

![gif](https://giphy.com/)
